### PR TITLE
Dot redesign

### DIFF
--- a/bsi_ops/benchmarks/benchmark_dot_kernel_micro.py
+++ b/bsi_ops/benchmarks/benchmark_dot_kernel_micro.py
@@ -1,0 +1,72 @@
+import argparse
+import time
+
+import torch
+
+import bsi_ops
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Microbench BSI dot kernel (CUDA)")
+    parser.add_argument("--Q", type=int, default=128, help="number of query vectors")
+    parser.add_argument("--R", type=int, default=256, help="number of keys")
+    parser.add_argument("--D", type=int, default=2048, help="input dimension")
+    parser.add_argument("--decimal_places", type=int, default=2)
+    parser.add_argument("--compress_threshold", type=float, default=0.5)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--report_stats", action="store_true",
+                        help="print Sb and S distributions from capsules")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this microbench")
+
+    torch.manual_seed(args.seed)
+    device = torch.device("cuda")
+
+    # Build random keys on CPU (builder moves to CUDA internally)
+    K = torch.randn(args.R, args.D, dtype=torch.float32, device="cpu")
+    keys_cap, _, _, _, _ = bsi_ops.build_bsi_keys_cuda(
+        K, args.decimal_places, float(args.compress_threshold)
+    )
+
+    # Build random queries on CUDA
+    Q = torch.randn(args.Q, args.D, dtype=torch.float32, device=device)
+    query_caps = bsi_ops.build_bsi_queries_cuda_batch(
+        Q, args.decimal_places, float(args.compress_threshold)
+    )
+
+    if args.report_stats:
+        key_stats = bsi_ops.bsi_keys_cuda_stats(keys_cap)
+        qry_stats = bsi_ops.bsi_query_caps_stats(query_caps)
+        print("[Keys]", dict(key_stats))
+        print("[Queries]", dict(qry_stats))
+
+    # Warmup
+    for _ in range(args.warmup):
+        bsi_ops.batch_dot_product_multiquery_cuda_caps(query_caps, keys_cap)
+
+    # Timed iterations: use kernel timings returned by the extension.
+    total_ns = 0
+    t0 = time.perf_counter()
+    for _ in range(args.iters):
+        _, dot_ns_total, _, _ = bsi_ops.batch_dot_product_multiquery_cuda_caps(
+            query_caps, keys_cap
+        )
+        total_ns += int(dot_ns_total)
+    t1 = time.perf_counter()
+
+    avg_ns = total_ns / max(1, args.iters)
+    avg_ms = avg_ns / 1e6
+    per_query_us = (avg_ns / args.Q) / 1e3 if args.Q > 0 else 0.0
+    per_scalar_ns = (avg_ns / (args.Q * args.R)) if (args.Q > 0 and args.R > 0) else 0.0
+
+    print(f"[Microbench] Q={args.Q} R={args.R} D={args.D} iters={args.iters}")
+    print(f"[Kernel] avg_dot_ms={avg_ms:.3f}  dot_q_us={per_query_us:.3f}  dot_s_ns={per_scalar_ns:.3f}")
+    print(f"[Wall] total_elapsed_s={t1 - t0:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bsi_ops/benchmarks/collect_bsi_shape_stats.py
+++ b/bsi_ops/benchmarks/collect_bsi_shape_stats.py
@@ -1,0 +1,61 @@
+import argparse
+from collections import Counter, defaultdict
+
+import torch
+from transformers import AutoModelForCausalLM
+
+import bsi_ops
+from bsi_ops.benchmarks.verify_accuracy_bsi import BSIQuantizedLinear
+from bsi_ops.benchmarks.benchmark_performance_bsi import quantize_model_bsi
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect BSI shape stats (Sb/W) per layer")
+    parser.add_argument("--model_name", type=str, required=True)
+    parser.add_argument("--decimal_places", type=int, default=2)
+    parser.add_argument("--compress_threshold", type=float, default=0.5)
+    parser.add_argument("--scope", type=str, default="all")
+    args = parser.parse_args()
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_name, torch_dtype=torch.float32, low_cpu_mem_usage=True
+    )
+    model.eval()
+
+    # Quantize in-place to BSI
+    model = quantize_model_bsi(
+        model,
+        decimalPlaces=args.decimal_places,
+        scope=args.scope,
+        compress_threshold=args.compress_threshold,
+    )
+
+    sb_hist = Counter()
+    w_hist = Counter()
+    layer_rows = []
+
+    for name, module in model.named_modules():
+        if isinstance(module, BSIQuantizedLinear):
+            stats = bsi_ops.bsi_keys_cuda_stats(module._bsi_keys_cuda)
+            w = int(stats["W"])
+            w_hist[w] += 1
+            sb_counts = stats["Sb_counts"]
+            for sb, cnt in sb_counts.items():
+                sb_hist[int(sb)] += int(cnt)
+            layer_rows.append((name, w, dict(sb_counts)))
+
+    print("=== W (words per slice) distribution across layers ===")
+    for w, cnt in sorted(w_hist.items()):
+        print(f"W={w}: {cnt} layers")
+
+    print("\n=== Sb (slices per key) distribution across all keys ===")
+    for sb, cnt in sorted(sb_hist.items()):
+        print(f"Sb={sb}: {cnt} keys")
+
+    print("\n=== Per-layer breakdown (name, W, Sb_counts) ===")
+    for name, w, sb_counts in layer_rows:
+        print(f"{name}: W={w}, Sb_counts={sb_counts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bsi_ops/benchmarks/collect_bsi_shape_stats.py
+++ b/bsi_ops/benchmarks/collect_bsi_shape_stats.py
@@ -30,11 +30,13 @@ def main() -> None:
     model.eval()
 
     # Quantize in-place to BSI
+    prefer_cuda = torch.cuda.is_available()
     model = quantize_model_bsi(
         model,
         decimalPlaces=args.decimal_places,
         scope=args.scope,
         compress_threshold=args.compress_threshold,
+        prefer_cuda=prefer_cuda,
     )
 
     sb_hist = Counter()

--- a/bsi_ops/benchmarks/collect_bsi_shape_stats.py
+++ b/bsi_ops/benchmarks/collect_bsi_shape_stats.py
@@ -1,12 +1,19 @@
 import argparse
 from collections import Counter, defaultdict
+import os
+import sys
 
 import torch
 from transformers import AutoModelForCausalLM
 
 import bsi_ops
-from bsi_ops.benchmarks.verify_accuracy_bsi import BSIQuantizedLinear
-from bsi_ops.benchmarks.benchmark_performance_bsi import quantize_model_bsi
+
+_BENCH_DIR = os.path.dirname(__file__)
+if _BENCH_DIR not in sys.path:
+    sys.path.insert(0, _BENCH_DIR)
+
+from verify_accuracy_bsi import BSIQuantizedLinear
+from benchmark_performance_bsi import quantize_model_bsi
 
 
 def main() -> None:

--- a/bsi_ops/csrc/cuda/bsi_cuda.cpp
+++ b/bsi_ops/csrc/cuda/bsi_cuda.cpp
@@ -109,11 +109,6 @@ struct PrebuiltBSIKeysCUDA {
     std::unordered_map<int, at::Tensor> grouped_weights; // Sb -> [R_sb, Sb]
     std::unordered_map<int, std::vector<int64_t>> grouped_indices; // Sb -> original key indices
     std::unordered_map<int, at::Tensor> grouped_indices_dev; // Sb -> [R_sb] int64 cuda
-    // Compressed grouped layout (EWAH):
-    // For each Sb group: a big 1D comp_words buffer, plus absolute per-slice offsets and lengths per key
-    std::unordered_map<int, at::Tensor> grouped_comp_words; // Sb -> [total_u64]
-    std::unordered_map<int, at::Tensor> grouped_comp_off;   // Sb -> [R_sb, Sb] (int64, absolute offsets)
-    std::unordered_map<int, at::Tensor> grouped_comp_len;   // Sb -> [R_sb, Sb] (int32)
     int W = 0;
     int64_t d = 0;
     int64_t num_keys = 0;
@@ -489,8 +484,6 @@ static pybind11::tuple build_bsi_keys_cuda(torch::Tensor K, int decimalPlaces, f
     holder->slice_weights.clear(); holder->slice_weights.reserve(num_keys);
     holder->metas.clear(); holder->metas.reserve(num_keys);
     holder->device_views.clear(); holder->device_views.reserve(num_keys);
-    std::vector<std::vector<u64>> comp_words_per_key(num_keys);
-    std::vector<std::vector<int>> comp_len_per_key(num_keys);
     size_t total_mem = 0;
     for (int64_t r = 0; r < num_keys; ++r) {
             std::vector<double> kv; kv.reserve(d);
@@ -510,14 +503,6 @@ static pybind11::tuple build_bsi_keys_cuda(torch::Tensor K, int decimalPlaces, f
             KeyMeta meta; meta.S = Sb; meta.offset = bsi_k->offset; meta.twos = bsi_k->twosComplement; meta.decimals = bsi_k->decimals;
             holder->metas.push_back(meta);
             total_mem += bsi_k->getSizeInMemory();
-            auto& comp_vec = comp_words_per_key[r]; comp_vec.clear();
-            auto& len_vec = comp_len_per_key[r]; len_vec.resize(Sb);
-            for (int s = 0; s < Sb; ++s) {
-                std::vector<u64> tmp;
-                hb_to_ewah_stream_helper<u64>(bsi_k->bsi[s], bsi_k->getNumberOfRows(), tmp);
-                len_vec[s] = (int)tmp.size();
-                comp_vec.insert(comp_vec.end(), tmp.begin(), tmp.end());
-            }
             delete bsi_k;
     }
     {
@@ -542,36 +527,6 @@ static pybind11::tuple build_bsi_keys_cuda(torch::Tensor K, int decimalPlaces, f
                 torch::TensorOptions().dtype(torch::kInt64)).clone();
             holder->grouped_indices_dev[Sb] = idx_cpu.to(torch::kCUDA).contiguous();
         }
-    }
-    for (const auto& kv : holder->grouped_indices) {
-        int Sb = kv.first; const auto& idxs = kv.second; int R = static_cast<int>(idxs.size());
-        long long total_u64 = 0;
-        std::vector<long long> h_off; h_off.resize((size_t)R * Sb);
-        std::vector<int> h_len; h_len.resize((size_t)R * Sb);
-        for (int i = 0; i < R; ++i) {
-            int64_t r = idxs[i];
-            const auto& lens = comp_len_per_key[r];
-            long long base = total_u64;
-            for (int s = 0; s < Sb; ++s) {
-                int L = (s < (int)lens.size()) ? lens[s] : 0;
-                h_off[(size_t)i * Sb + s] = base;
-                h_len[(size_t)i * Sb + s] = L;
-                base += L;
-            }
-            total_u64 = base;
-        }
-        std::vector<u64> h_comp; h_comp.reserve((size_t)total_u64);
-        for (int i = 0; i < R; ++i) {
-            int64_t r = idxs[i];
-            const auto& comp = comp_words_per_key[r];
-            h_comp.insert(h_comp.end(), comp.begin(), comp.end());
-        }
-        auto d_comp = torch::from_blob(h_comp.data(), {total_u64}, torch::TensorOptions().dtype(torch::kInt64)).clone().to(torch::kCUDA);
-        auto d_off = torch::from_blob(h_off.data(), {R, Sb}, torch::TensorOptions().dtype(torch::kInt64)).clone().to(torch::kCUDA);
-        auto d_len = torch::from_blob(h_len.data(), {R, Sb}, torch::TensorOptions().dtype(torch::kInt32)).clone().to(torch::kCUDA);
-        holder->grouped_comp_words[Sb] = d_comp.contiguous();
-        holder->grouped_comp_off[Sb] = d_off.contiguous();
-        holder->grouped_comp_len[Sb] = d_len.contiguous();
     }
     pybind11::capsule cap(holder, "PrebuiltBSIKeysCUDA",
         [](PyObject* capsule){

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -612,11 +612,14 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
                         unsigned long long a3 = a_ptr[96];
 #pragma unroll
                         for (int j = 0; j < SB; ++j) {
-                            int cnt = __popcll(a0 & b_cache0[j]);
+                            unsigned long long cnt = __popcll(a0 & b_cache0[j]);
                             cnt += __popcll(a1 & b_cache1[j]);
                             cnt += __popcll(a2 & b_cache2[j]);
                             cnt += __popcll(a3 & b_cache3[j]);
-                            local += (float)cnt * aw * bw_cache[j];
+                            cnt = warp_reduce_sum_ull(cnt);
+                            if (lane == 0) {
+                                local += (float)cnt * aw * bw_cache[j];
+                            }
                         }
                     }
                     a_ptr += Wc;
@@ -634,16 +637,18 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
                     a_ptr += Wc;
 #pragma unroll
                     for (int j = 0; j < SB; ++j) {
-                        int cnt = __popcll(a0 & b_cache0[j]);
+                        unsigned long long cnt = __popcll(a0 & b_cache0[j]);
                         cnt += __popcll(a1 & b_cache1[j]);
                         cnt += __popcll(a2 & b_cache2[j]);
                         cnt += __popcll(a3 & b_cache3[j]);
-                        local += (float)cnt * aw * bw_cache[j];
+                        cnt = warp_reduce_sum_ull(cnt);
+                        if (lane == 0) {
+                            local += (float)cnt * aw * bw_cache[j];
+                        }
                     }
                 }
             }
 
-            local = warp_reduce_sum_float(local);
             if (lane == 0) {
                 out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
             }
@@ -791,8 +796,11 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_
                         unsigned long long a_val = *a_ptr;
 #pragma unroll
                         for (int j = 0; j < SB; ++j) {
-                            int cnt = __popcll(a_val & b_cache[j]);
-                            local += (float)cnt * aw * bw_cache[j];
+                            unsigned long long cnt = __popcll(a_val & b_cache[j]);
+                            cnt = warp_reduce_sum_ull(cnt);
+                            if (lane == 0) {
+                                local += (float)cnt * aw * bw_cache[j];
+                            }
                         }
                     }
                     a_ptr += Wc;
@@ -807,13 +815,15 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_
                     a_ptr += Wc;
 #pragma unroll
                     for (int j = 0; j < SB; ++j) {
-                        int cnt = __popcll(a_val & b_cache[j]);
-                        local += (float)cnt * aw * bw_cache[j];
+                        unsigned long long cnt = __popcll(a_val & b_cache[j]);
+                        cnt = warp_reduce_sum_ull(cnt);
+                        if (lane == 0) {
+                            local += (float)cnt * aw * bw_cache[j];
+                        }
                     }
                 }
             }
 
-            local = warp_reduce_sum_float(local);
             if (lane == 0) {
                 out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
             }

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -612,14 +612,11 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
                         unsigned long long a3 = a_ptr[96];
 #pragma unroll
                         for (int j = 0; j < SB; ++j) {
-                            unsigned long long cnt = __popcll(a0 & b_cache0[j]);
+                            int cnt = __popcll(a0 & b_cache0[j]);
                             cnt += __popcll(a1 & b_cache1[j]);
                             cnt += __popcll(a2 & b_cache2[j]);
                             cnt += __popcll(a3 & b_cache3[j]);
-                            cnt = warp_reduce_sum_ull(cnt);
-                            if (lane == 0) {
-                                local += (float)cnt * aw * bw_cache[j];
-                            }
+                            local += (float)cnt * aw * bw_cache[j];
                         }
                     }
                     a_ptr += Wc;
@@ -637,18 +634,16 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
                     a_ptr += Wc;
 #pragma unroll
                     for (int j = 0; j < SB; ++j) {
-                        unsigned long long cnt = __popcll(a0 & b_cache0[j]);
+                        int cnt = __popcll(a0 & b_cache0[j]);
                         cnt += __popcll(a1 & b_cache1[j]);
                         cnt += __popcll(a2 & b_cache2[j]);
                         cnt += __popcll(a3 & b_cache3[j]);
-                        cnt = warp_reduce_sum_ull(cnt);
-                        if (lane == 0) {
-                            local += (float)cnt * aw * bw_cache[j];
-                        }
+                        local += (float)cnt * aw * bw_cache[j];
                     }
                 }
             }
 
+            local = warp_reduce_sum_float(local);
             if (lane == 0) {
                 out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
             }
@@ -796,11 +791,8 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_
                         unsigned long long a_val = *a_ptr;
 #pragma unroll
                         for (int j = 0; j < SB; ++j) {
-                            unsigned long long cnt = __popcll(a_val & b_cache[j]);
-                            cnt = warp_reduce_sum_ull(cnt);
-                            if (lane == 0) {
-                                local += (float)cnt * aw * bw_cache[j];
-                            }
+                            int cnt = __popcll(a_val & b_cache[j]);
+                            local += (float)cnt * aw * bw_cache[j];
                         }
                     }
                     a_ptr += Wc;
@@ -815,15 +807,13 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_
                     a_ptr += Wc;
 #pragma unroll
                     for (int j = 0; j < SB; ++j) {
-                        unsigned long long cnt = __popcll(a_val & b_cache[j]);
-                        cnt = warp_reduce_sum_ull(cnt);
-                        if (lane == 0) {
-                            local += (float)cnt * aw * bw_cache[j];
-                        }
+                        int cnt = __popcll(a_val & b_cache[j]);
+                        local += (float)cnt * aw * bw_cache[j];
                     }
                 }
             }
 
+            local = warp_reduce_sum_float(local);
             if (lane == 0) {
                 out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
             }

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -656,6 +656,364 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
     }
 }
 
+__global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8(
+    const unsigned long long* __restrict__ A,    // [Q, Sa, 32]
+    const float* __restrict__ Aw,                // [Q, Sa]
+    int Sa,
+    int W,
+    const unsigned long long* __restrict__ B,    // [R, 8, 32]
+    const float* __restrict__ Bw,                // [R, 8]
+    int Sb,
+    int R,
+    int Q,
+    int q_tile,
+    int r_tile,
+    const long long* __restrict__ key_indices,   // [R]
+    const long long* __restrict__ query_indices, // [Q]
+    const int* __restrict__ sb_len,
+    float scale_inv,
+    int R_total,
+    float* __restrict__ out_global)
+{
+    constexpr int Wc = 32;
+    constexpr int SB = 8;
+    (void)W;
+    (void)Sb;
+
+    extern __shared__ unsigned char shmem[];
+    int r_block = blockIdx.x;
+    int q_block = blockIdx.y;
+    const int tile_q = (q_tile > 0) ? q_tile : 1;
+    const int tile_r = (r_tile > 0) ? r_tile : 1;
+    const int q_start = q_block * tile_q;
+    const int r_start = r_block * tile_r;
+    if (q_start >= Q) return;
+
+    const int lane = threadIdx.x & 31;
+    const int warp_id = threadIdx.x >> 5;
+    const int num_warps = (blockDim.x + 31) >> 5;
+
+    unsigned long long* A_sh0 = reinterpret_cast<unsigned long long*>(shmem);
+    unsigned long long* A_sh1 = A_sh0 + (size_t)Sa * (size_t)Wc;
+    unsigned long long* B_sh = A_sh1 + (size_t)Sa * (size_t)Wc;
+    float* Aw_sh0 = reinterpret_cast<float*>(B_sh + (size_t)tile_r * (size_t)SB * (size_t)Wc);
+    float* Aw_sh1 = Aw_sh0 + Sa;
+    float* Bw_sh = Aw_sh1 + Sa;
+
+    for (int tr = 0; tr < tile_r; ++tr) {
+        int r = r_start + tr;
+        if (r >= R) continue;
+        const unsigned long long* B_base = B + ((size_t)r * (size_t)SB * (size_t)Wc);
+        const float* Bw_base = Bw + ((size_t)r * (size_t)SB);
+        for (int idx = threadIdx.x; idx < SB * Wc; idx += blockDim.x) {
+            B_sh[(size_t)tr * (size_t)SB * (size_t)Wc + (size_t)idx] = __ldg(&B_base[idx]);
+        }
+        for (int idx = threadIdx.x; idx < SB; idx += blockDim.x) {
+            Bw_sh[(size_t)tr * (size_t)SB + (size_t)idx] = __ldg(&Bw_base[idx]);
+        }
+    }
+    __syncthreads();
+
+    int q_end = q_start + tile_q;
+    if (q_end > Q) q_end = Q;
+    if (q_start >= q_end) return;
+
+    int buf0 = q_start & 1;
+    const unsigned long long* A_base0 = A + ((size_t)q_start * (size_t)Sa * (size_t)Wc);
+    if (buf0 == 0) {
+        cp_async_copy_ull(A_sh0, A_base0, Sa * Wc);
+    } else {
+        cp_async_copy_ull(A_sh1, A_base0, Sa * Wc);
+    }
+    cp_async_commit();
+    cp_async_wait();
+    if (buf0 == 0) {
+        cp_async_tail_ull(A_sh0, A_base0, Sa * Wc);
+    } else {
+        cp_async_tail_ull(A_sh1, A_base0, Sa * Wc);
+    }
+    __syncthreads();
+
+    for (int q = q_start; q < q_end; ++q) {
+        int buf = q & 1;
+        unsigned long long* A_sh = buf ? A_sh1 : A_sh0;
+        float* Aw_sh = buf ? Aw_sh1 : Aw_sh0;
+
+        long long global_q = __ldg(&query_indices[q]);
+        const float* Aw_base = Aw + ((size_t)q * (size_t)Sa);
+        int q_next = q + 1;
+        unsigned long long* A_sh_next = nullptr;
+        const unsigned long long* A_base_next = nullptr;
+        if (q_next < q_end) {
+            A_base_next = A + ((size_t)q_next * (size_t)Sa * (size_t)Wc);
+            A_sh_next = buf ? A_sh0 : A_sh1;
+            cp_async_copy_ull(A_sh_next, A_base_next, Sa * Wc);
+            cp_async_commit();
+        }
+
+        for (int idx = threadIdx.x; idx < Sa; idx += blockDim.x) {
+            Aw_sh[idx] = __ldg(&Aw_base[idx]);
+        }
+        __syncthreads();
+
+        for (int out_idx = warp_id; out_idx < tile_r; out_idx += num_warps) {
+            int r = r_start + out_idx;
+            if (r >= R) continue;
+            long long global_r = __ldg(&key_indices[r]);
+            int sbn = sb_len ? __ldg(&sb_len[r]) : SB;
+            if (sbn <= 0) continue;
+
+            float local = 0.0f;
+            const unsigned long long* b_row =
+                B_sh + (size_t)out_idx * (size_t)SB * (size_t)Wc + (size_t)lane;
+            const float* bw_row = Bw_sh + (size_t)out_idx * (size_t)SB;
+            const unsigned int full_mask = 0xffffffffu;
+
+            float bw_cache[SB];
+            unsigned long long b_cache[SB];
+            const unsigned long long* b_ptr_init = b_row;
+#pragma unroll
+            for (int j = 0; j < SB; ++j) {
+                bool ok = (j < sbn);
+                bw_cache[j] = ok ? bw_row[j] : 0.0f;
+                b_cache[j] = ok ? *b_ptr_init : 0ull;
+                b_ptr_init += Wc;
+            }
+
+            if (Sa <= 16) {
+                const unsigned long long* a_ptr = A_sh + (size_t)lane;
+#pragma unroll
+                for (int i = 0; i < 16; ++i) {
+                    float aw = 0.0f;
+                    if (i < Sa) {
+                        if (lane == 0) aw = Aw_sh[i];
+                        aw = __shfl_sync(full_mask, aw, 0);
+                        unsigned long long a_val = *a_ptr;
+#pragma unroll
+                        for (int j = 0; j < SB; ++j) {
+                            int cnt = __popcll(a_val & b_cache[j]);
+                            local += (float)cnt * aw * bw_cache[j];
+                        }
+                    }
+                    a_ptr += Wc;
+                }
+            } else {
+                const unsigned long long* a_ptr = A_sh + (size_t)lane;
+                for (int i = 0; i < Sa; ++i) {
+                    float aw = 0.0f;
+                    if (lane == 0) aw = Aw_sh[i];
+                    aw = __shfl_sync(full_mask, aw, 0);
+                    unsigned long long a_val = *a_ptr;
+                    a_ptr += Wc;
+#pragma unroll
+                    for (int j = 0; j < SB; ++j) {
+                        int cnt = __popcll(a_val & b_cache[j]);
+                        local += (float)cnt * aw * bw_cache[j];
+                    }
+                }
+            }
+
+            local = warp_reduce_sum_float(local);
+            if (lane == 0) {
+                out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
+            }
+        }
+        if (q_next < q_end) {
+            cp_async_wait();
+            cp_async_tail_ull(A_sh_next, A_base_next, Sa * Wc);
+            __syncthreads();
+        }
+    }
+}
+
+__global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8(
+    const unsigned long long* __restrict__ A,    // [Q, Sa, 128]
+    const float* __restrict__ Aw,                // [Q, Sa]
+    int Sa,
+    int W,
+    const unsigned long long* __restrict__ B,    // [R, 8, 128]
+    const float* __restrict__ Bw,                // [R, 8]
+    int Sb,
+    int R,
+    int Q,
+    int q_tile,
+    int r_tile,
+    const long long* __restrict__ key_indices,   // [R]
+    const long long* __restrict__ query_indices, // [Q]
+    const int* __restrict__ sb_len,
+    float scale_inv,
+    int R_total,
+    float* __restrict__ out_global)
+{
+    constexpr int Wc = 128;
+    constexpr int SB = 8;
+    (void)W;
+    (void)Sb;
+
+    extern __shared__ unsigned char shmem[];
+    int r_block = blockIdx.x;
+    int q_block = blockIdx.y;
+    const int tile_q = (q_tile > 0) ? q_tile : 1;
+    const int tile_r = (r_tile > 0) ? r_tile : 1;
+    const int q_start = q_block * tile_q;
+    const int r_start = r_block * tile_r;
+    if (q_start >= Q) return;
+
+    const int lane = threadIdx.x & 31;
+    const int warp_id = threadIdx.x >> 5;
+    const int num_warps = (blockDim.x + 31) >> 5;
+
+    unsigned long long* A_sh0 = reinterpret_cast<unsigned long long*>(shmem);
+    unsigned long long* A_sh1 = A_sh0 + (size_t)Sa * (size_t)Wc;
+    unsigned long long* B_sh = A_sh1 + (size_t)Sa * (size_t)Wc;
+    float* Aw_sh0 = reinterpret_cast<float*>(B_sh + (size_t)tile_r * (size_t)SB * (size_t)Wc);
+    float* Aw_sh1 = Aw_sh0 + Sa;
+    float* Bw_sh = Aw_sh1 + Sa;
+
+    for (int tr = 0; tr < tile_r; ++tr) {
+        int r = r_start + tr;
+        if (r >= R) continue;
+        const unsigned long long* B_base = B + ((size_t)r * (size_t)SB * (size_t)Wc);
+        const float* Bw_base = Bw + ((size_t)r * (size_t)SB);
+        for (int idx = threadIdx.x; idx < SB * Wc; idx += blockDim.x) {
+            B_sh[(size_t)tr * (size_t)SB * (size_t)Wc + (size_t)idx] = __ldg(&B_base[idx]);
+        }
+        for (int idx = threadIdx.x; idx < SB; idx += blockDim.x) {
+            Bw_sh[(size_t)tr * (size_t)SB + (size_t)idx] = __ldg(&Bw_base[idx]);
+        }
+    }
+    __syncthreads();
+
+    int q_end = q_start + tile_q;
+    if (q_end > Q) q_end = Q;
+    if (q_start >= q_end) return;
+
+    int buf0 = q_start & 1;
+    const unsigned long long* A_base0 = A + ((size_t)q_start * (size_t)Sa * (size_t)Wc);
+    if (buf0 == 0) {
+        cp_async_copy_ull(A_sh0, A_base0, Sa * Wc);
+    } else {
+        cp_async_copy_ull(A_sh1, A_base0, Sa * Wc);
+    }
+    cp_async_commit();
+    cp_async_wait();
+    if (buf0 == 0) {
+        cp_async_tail_ull(A_sh0, A_base0, Sa * Wc);
+    } else {
+        cp_async_tail_ull(A_sh1, A_base0, Sa * Wc);
+    }
+    __syncthreads();
+
+    for (int q = q_start; q < q_end; ++q) {
+        int buf = q & 1;
+        unsigned long long* A_sh = buf ? A_sh1 : A_sh0;
+        float* Aw_sh = buf ? Aw_sh1 : Aw_sh0;
+
+        long long global_q = __ldg(&query_indices[q]);
+        const float* Aw_base = Aw + ((size_t)q * (size_t)Sa);
+        int q_next = q + 1;
+        unsigned long long* A_sh_next = nullptr;
+        const unsigned long long* A_base_next = nullptr;
+        if (q_next < q_end) {
+            A_base_next = A + ((size_t)q_next * (size_t)Sa * (size_t)Wc);
+            A_sh_next = buf ? A_sh0 : A_sh1;
+            cp_async_copy_ull(A_sh_next, A_base_next, Sa * Wc);
+            cp_async_commit();
+        }
+
+        for (int idx = threadIdx.x; idx < Sa; idx += blockDim.x) {
+            Aw_sh[idx] = __ldg(&Aw_base[idx]);
+        }
+        __syncthreads();
+
+        for (int out_idx = warp_id; out_idx < tile_r; out_idx += num_warps) {
+            int r = r_start + out_idx;
+            if (r >= R) continue;
+            long long global_r = __ldg(&key_indices[r]);
+            int sbn = sb_len ? __ldg(&sb_len[r]) : SB;
+            if (sbn <= 0) continue;
+
+            float local = 0.0f;
+            const unsigned long long* b_row =
+                B_sh + (size_t)out_idx * (size_t)SB * (size_t)Wc + (size_t)lane;
+            const float* bw_row = Bw_sh + (size_t)out_idx * (size_t)SB;
+            const unsigned int full_mask = 0xffffffffu;
+
+            float bw_cache[SB];
+            unsigned long long b_cache0[SB];
+            unsigned long long b_cache1[SB];
+            unsigned long long b_cache2[SB];
+            unsigned long long b_cache3[SB];
+            const unsigned long long* b_ptr_init = b_row;
+#pragma unroll
+            for (int j = 0; j < SB; ++j) {
+                bool ok = (j < sbn);
+                bw_cache[j] = ok ? bw_row[j] : 0.0f;
+                b_cache0[j] = ok ? b_ptr_init[0] : 0ull;
+                b_cache1[j] = ok ? b_ptr_init[32] : 0ull;
+                b_cache2[j] = ok ? b_ptr_init[64] : 0ull;
+                b_cache3[j] = ok ? b_ptr_init[96] : 0ull;
+                b_ptr_init += Wc;
+            }
+
+            if (Sa <= 16) {
+                const unsigned long long* a_ptr = A_sh + (size_t)lane;
+#pragma unroll
+                for (int i = 0; i < 16; ++i) {
+                    float aw = 0.0f;
+                    if (i < Sa) {
+                        if (lane == 0) aw = Aw_sh[i];
+                        aw = __shfl_sync(full_mask, aw, 0);
+                        unsigned long long a0 = a_ptr[0];
+                        unsigned long long a1 = a_ptr[32];
+                        unsigned long long a2 = a_ptr[64];
+                        unsigned long long a3 = a_ptr[96];
+#pragma unroll
+                        for (int j = 0; j < SB; ++j) {
+                            int cnt = __popcll(a0 & b_cache0[j]);
+                            cnt += __popcll(a1 & b_cache1[j]);
+                            cnt += __popcll(a2 & b_cache2[j]);
+                            cnt += __popcll(a3 & b_cache3[j]);
+                            local += (float)cnt * aw * bw_cache[j];
+                        }
+                    }
+                    a_ptr += Wc;
+                }
+            } else {
+                const unsigned long long* a_ptr = A_sh + (size_t)lane;
+                for (int i = 0; i < Sa; ++i) {
+                    float aw = 0.0f;
+                    if (lane == 0) aw = Aw_sh[i];
+                    aw = __shfl_sync(full_mask, aw, 0);
+                    unsigned long long a0 = a_ptr[0];
+                    unsigned long long a1 = a_ptr[32];
+                    unsigned long long a2 = a_ptr[64];
+                    unsigned long long a3 = a_ptr[96];
+                    a_ptr += Wc;
+#pragma unroll
+                    for (int j = 0; j < SB; ++j) {
+                        int cnt = __popcll(a0 & b_cache0[j]);
+                        cnt += __popcll(a1 & b_cache1[j]);
+                        cnt += __popcll(a2 & b_cache2[j]);
+                        cnt += __popcll(a3 & b_cache3[j]);
+                        local += (float)cnt * aw * bw_cache[j];
+                    }
+                }
+            }
+
+            local = warp_reduce_sum_float(local);
+            if (lane == 0) {
+                out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
+            }
+        }
+        if (q_next < q_end) {
+            cp_async_wait();
+            cp_async_tail_ull(A_sh_next, A_base_next, Sa * Wc);
+            __syncthreads();
+        }
+    }
+}
+
 template <int SB>
 static inline void launch_w32_sb_kernel(
     const unsigned long long* A,
@@ -724,6 +1082,74 @@ static inline void launch_w128_sb_kernel(
         A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, scale_inv, R_total, out_global);
 }
 
+static inline void launch_w32_sb_var8(
+    const unsigned long long* A,
+    const float* Aw,
+    int Sa,
+    int W,
+    const unsigned long long* B,
+    const float* Bw,
+    int Sb,
+    int R,
+    int Q,
+    int tile_q,
+    int tile_r,
+    const long long* indices_r,
+    const long long* indices_q,
+    const int* sb_len,
+    float scale_inv,
+    int R_total,
+    float* out_global,
+    size_t shared_bytes,
+    dim3 grid_warp,
+    dim3 block,
+    cudaStream_t stream,
+    int max_shared_default)
+{
+    if (shared_bytes > (size_t)max_shared_default) {
+        cudaFuncSetAttribute(
+            popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8,
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            (int)shared_bytes);
+    }
+    popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8<<<grid_warp, block, shared_bytes, stream>>>(
+        A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, sb_len, scale_inv, R_total, out_global);
+}
+
+static inline void launch_w128_sb_var8(
+    const unsigned long long* A,
+    const float* Aw,
+    int Sa,
+    int W,
+    const unsigned long long* B,
+    const float* Bw,
+    int Sb,
+    int R,
+    int Q,
+    int tile_q,
+    int tile_r,
+    const long long* indices_r,
+    const long long* indices_q,
+    const int* sb_len,
+    float scale_inv,
+    int R_total,
+    float* out_global,
+    size_t shared_bytes,
+    dim3 grid_warp,
+    dim3 block,
+    cudaStream_t stream,
+    int max_shared_default)
+{
+    if (shared_bytes > (size_t)max_shared_default) {
+        cudaFuncSetAttribute(
+            popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8,
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            (int)shared_bytes);
+    }
+    popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8<<<grid_warp, block, shared_bytes, stream>>>(
+        A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, sb_len, scale_inv, R_total, out_global);
+}
+
 extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
     const unsigned long long* A,
     const float* Aw,
@@ -738,6 +1164,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
     int r_tile,
     const long long* indices_r,
     const long long* indices_q,
+    const int* sb_len,
     float scale_inv,
     int R_total,
     float* out_global,
@@ -774,6 +1201,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
         int max_shared = (max_shared_optin > max_shared_default) ? max_shared_optin : max_shared_default;
         bool use_w32 = (W == 32 && Sb >= 1 && Sb <= 16);
         bool use_w128 = (W == 128 && Sb >= 1 && Sb <= 8);
+        bool use_sb_len = (sb_len != nullptr && Sb == 8);
         size_t a_word_factor = (use_w32 || use_w128) ? 2u : 1u;
         size_t a_float_factor = (use_w32 || use_w128) ? 2u : 1u;
         int tile_r_eff = tile_r;
@@ -794,6 +1222,10 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
         } else {
             dim3 grid_warp((R + tile_r_eff - 1) / tile_r_eff, (Q + tile_q - 1) / tile_q);
             if (use_w32) {
+                if (use_sb_len) {
+                    launch_w32_sb_var8(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
+                                       sb_len, scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
+                } else {
                 switch (Sb) {
                     case 1:
                         launch_w32_sb_kernel<1>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
@@ -861,7 +1293,12 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                                                      scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
                         break;
                 }
+                }
             } else if (use_w128) {
+                if (use_sb_len) {
+                    launch_w128_sb_var8(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
+                                        sb_len, scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
+                } else {
                 switch (Sb) {
                     case 1:
                         launch_w128_sb_kernel<1>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
@@ -896,6 +1333,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                         launch_w128_sb_kernel<8>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
                                                      scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
                         break;
+                }
                 }
             } else {
                 if (shared_bytes > (size_t)max_shared_default) {

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -656,364 +656,6 @@ __global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128
     }
 }
 
-__global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8(
-    const unsigned long long* __restrict__ A,    // [Q, Sa, 32]
-    const float* __restrict__ Aw,                // [Q, Sa]
-    int Sa,
-    int W,
-    const unsigned long long* __restrict__ B,    // [R, 8, 32]
-    const float* __restrict__ Bw,                // [R, 8]
-    int Sb,
-    int R,
-    int Q,
-    int q_tile,
-    int r_tile,
-    const long long* __restrict__ key_indices,   // [R]
-    const long long* __restrict__ query_indices, // [Q]
-    const int* __restrict__ sb_len,
-    float scale_inv,
-    int R_total,
-    float* __restrict__ out_global)
-{
-    constexpr int Wc = 32;
-    constexpr int SB = 8;
-    (void)W;
-    (void)Sb;
-
-    extern __shared__ unsigned char shmem[];
-    int r_block = blockIdx.x;
-    int q_block = blockIdx.y;
-    const int tile_q = (q_tile > 0) ? q_tile : 1;
-    const int tile_r = (r_tile > 0) ? r_tile : 1;
-    const int q_start = q_block * tile_q;
-    const int r_start = r_block * tile_r;
-    if (q_start >= Q) return;
-
-    const int lane = threadIdx.x & 31;
-    const int warp_id = threadIdx.x >> 5;
-    const int num_warps = (blockDim.x + 31) >> 5;
-
-    unsigned long long* A_sh0 = reinterpret_cast<unsigned long long*>(shmem);
-    unsigned long long* A_sh1 = A_sh0 + (size_t)Sa * (size_t)Wc;
-    unsigned long long* B_sh = A_sh1 + (size_t)Sa * (size_t)Wc;
-    float* Aw_sh0 = reinterpret_cast<float*>(B_sh + (size_t)tile_r * (size_t)SB * (size_t)Wc);
-    float* Aw_sh1 = Aw_sh0 + Sa;
-    float* Bw_sh = Aw_sh1 + Sa;
-
-    for (int tr = 0; tr < tile_r; ++tr) {
-        int r = r_start + tr;
-        if (r >= R) continue;
-        const unsigned long long* B_base = B + ((size_t)r * (size_t)SB * (size_t)Wc);
-        const float* Bw_base = Bw + ((size_t)r * (size_t)SB);
-        for (int idx = threadIdx.x; idx < SB * Wc; idx += blockDim.x) {
-            B_sh[(size_t)tr * (size_t)SB * (size_t)Wc + (size_t)idx] = __ldg(&B_base[idx]);
-        }
-        for (int idx = threadIdx.x; idx < SB; idx += blockDim.x) {
-            Bw_sh[(size_t)tr * (size_t)SB + (size_t)idx] = __ldg(&Bw_base[idx]);
-        }
-    }
-    __syncthreads();
-
-    int q_end = q_start + tile_q;
-    if (q_end > Q) q_end = Q;
-    if (q_start >= q_end) return;
-
-    int buf0 = q_start & 1;
-    const unsigned long long* A_base0 = A + ((size_t)q_start * (size_t)Sa * (size_t)Wc);
-    if (buf0 == 0) {
-        cp_async_copy_ull(A_sh0, A_base0, Sa * Wc);
-    } else {
-        cp_async_copy_ull(A_sh1, A_base0, Sa * Wc);
-    }
-    cp_async_commit();
-    cp_async_wait();
-    if (buf0 == 0) {
-        cp_async_tail_ull(A_sh0, A_base0, Sa * Wc);
-    } else {
-        cp_async_tail_ull(A_sh1, A_base0, Sa * Wc);
-    }
-    __syncthreads();
-
-    for (int q = q_start; q < q_end; ++q) {
-        int buf = q & 1;
-        unsigned long long* A_sh = buf ? A_sh1 : A_sh0;
-        float* Aw_sh = buf ? Aw_sh1 : Aw_sh0;
-
-        long long global_q = __ldg(&query_indices[q]);
-        const float* Aw_base = Aw + ((size_t)q * (size_t)Sa);
-        int q_next = q + 1;
-        unsigned long long* A_sh_next = nullptr;
-        const unsigned long long* A_base_next = nullptr;
-        if (q_next < q_end) {
-            A_base_next = A + ((size_t)q_next * (size_t)Sa * (size_t)Wc);
-            A_sh_next = buf ? A_sh0 : A_sh1;
-            cp_async_copy_ull(A_sh_next, A_base_next, Sa * Wc);
-            cp_async_commit();
-        }
-
-        for (int idx = threadIdx.x; idx < Sa; idx += blockDim.x) {
-            Aw_sh[idx] = __ldg(&Aw_base[idx]);
-        }
-        __syncthreads();
-
-        for (int out_idx = warp_id; out_idx < tile_r; out_idx += num_warps) {
-            int r = r_start + out_idx;
-            if (r >= R) continue;
-            long long global_r = __ldg(&key_indices[r]);
-            int sbn = sb_len ? __ldg(&sb_len[r]) : SB;
-            if (sbn <= 0) continue;
-
-            float local = 0.0f;
-            const unsigned long long* b_row =
-                B_sh + (size_t)out_idx * (size_t)SB * (size_t)Wc + (size_t)lane;
-            const float* bw_row = Bw_sh + (size_t)out_idx * (size_t)SB;
-            const unsigned int full_mask = 0xffffffffu;
-
-            float bw_cache[SB];
-            unsigned long long b_cache[SB];
-            const unsigned long long* b_ptr_init = b_row;
-#pragma unroll
-            for (int j = 0; j < SB; ++j) {
-                bool ok = (j < sbn);
-                bw_cache[j] = ok ? bw_row[j] : 0.0f;
-                b_cache[j] = ok ? *b_ptr_init : 0ull;
-                b_ptr_init += Wc;
-            }
-
-            if (Sa <= 16) {
-                const unsigned long long* a_ptr = A_sh + (size_t)lane;
-#pragma unroll
-                for (int i = 0; i < 16; ++i) {
-                    float aw = 0.0f;
-                    if (i < Sa) {
-                        if (lane == 0) aw = Aw_sh[i];
-                        aw = __shfl_sync(full_mask, aw, 0);
-                        unsigned long long a_val = *a_ptr;
-#pragma unroll
-                        for (int j = 0; j < SB; ++j) {
-                            int cnt = __popcll(a_val & b_cache[j]);
-                            local += (float)cnt * aw * bw_cache[j];
-                        }
-                    }
-                    a_ptr += Wc;
-                }
-            } else {
-                const unsigned long long* a_ptr = A_sh + (size_t)lane;
-                for (int i = 0; i < Sa; ++i) {
-                    float aw = 0.0f;
-                    if (lane == 0) aw = Aw_sh[i];
-                    aw = __shfl_sync(full_mask, aw, 0);
-                    unsigned long long a_val = *a_ptr;
-                    a_ptr += Wc;
-#pragma unroll
-                    for (int j = 0; j < SB; ++j) {
-                        int cnt = __popcll(a_val & b_cache[j]);
-                        local += (float)cnt * aw * bw_cache[j];
-                    }
-                }
-            }
-
-            local = warp_reduce_sum_float(local);
-            if (lane == 0) {
-                out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
-            }
-        }
-        if (q_next < q_end) {
-            cp_async_wait();
-            cp_async_tail_ull(A_sh_next, A_base_next, Sa * Wc);
-            __syncthreads();
-        }
-    }
-}
-
-__global__ void popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8(
-    const unsigned long long* __restrict__ A,    // [Q, Sa, 128]
-    const float* __restrict__ Aw,                // [Q, Sa]
-    int Sa,
-    int W,
-    const unsigned long long* __restrict__ B,    // [R, 8, 128]
-    const float* __restrict__ Bw,                // [R, 8]
-    int Sb,
-    int R,
-    int Q,
-    int q_tile,
-    int r_tile,
-    const long long* __restrict__ key_indices,   // [R]
-    const long long* __restrict__ query_indices, // [Q]
-    const int* __restrict__ sb_len,
-    float scale_inv,
-    int R_total,
-    float* __restrict__ out_global)
-{
-    constexpr int Wc = 128;
-    constexpr int SB = 8;
-    (void)W;
-    (void)Sb;
-
-    extern __shared__ unsigned char shmem[];
-    int r_block = blockIdx.x;
-    int q_block = blockIdx.y;
-    const int tile_q = (q_tile > 0) ? q_tile : 1;
-    const int tile_r = (r_tile > 0) ? r_tile : 1;
-    const int q_start = q_block * tile_q;
-    const int r_start = r_block * tile_r;
-    if (q_start >= Q) return;
-
-    const int lane = threadIdx.x & 31;
-    const int warp_id = threadIdx.x >> 5;
-    const int num_warps = (blockDim.x + 31) >> 5;
-
-    unsigned long long* A_sh0 = reinterpret_cast<unsigned long long*>(shmem);
-    unsigned long long* A_sh1 = A_sh0 + (size_t)Sa * (size_t)Wc;
-    unsigned long long* B_sh = A_sh1 + (size_t)Sa * (size_t)Wc;
-    float* Aw_sh0 = reinterpret_cast<float*>(B_sh + (size_t)tile_r * (size_t)SB * (size_t)Wc);
-    float* Aw_sh1 = Aw_sh0 + Sa;
-    float* Bw_sh = Aw_sh1 + Sa;
-
-    for (int tr = 0; tr < tile_r; ++tr) {
-        int r = r_start + tr;
-        if (r >= R) continue;
-        const unsigned long long* B_base = B + ((size_t)r * (size_t)SB * (size_t)Wc);
-        const float* Bw_base = Bw + ((size_t)r * (size_t)SB);
-        for (int idx = threadIdx.x; idx < SB * Wc; idx += blockDim.x) {
-            B_sh[(size_t)tr * (size_t)SB * (size_t)Wc + (size_t)idx] = __ldg(&B_base[idx]);
-        }
-        for (int idx = threadIdx.x; idx < SB; idx += blockDim.x) {
-            Bw_sh[(size_t)tr * (size_t)SB + (size_t)idx] = __ldg(&Bw_base[idx]);
-        }
-    }
-    __syncthreads();
-
-    int q_end = q_start + tile_q;
-    if (q_end > Q) q_end = Q;
-    if (q_start >= q_end) return;
-
-    int buf0 = q_start & 1;
-    const unsigned long long* A_base0 = A + ((size_t)q_start * (size_t)Sa * (size_t)Wc);
-    if (buf0 == 0) {
-        cp_async_copy_ull(A_sh0, A_base0, Sa * Wc);
-    } else {
-        cp_async_copy_ull(A_sh1, A_base0, Sa * Wc);
-    }
-    cp_async_commit();
-    cp_async_wait();
-    if (buf0 == 0) {
-        cp_async_tail_ull(A_sh0, A_base0, Sa * Wc);
-    } else {
-        cp_async_tail_ull(A_sh1, A_base0, Sa * Wc);
-    }
-    __syncthreads();
-
-    for (int q = q_start; q < q_end; ++q) {
-        int buf = q & 1;
-        unsigned long long* A_sh = buf ? A_sh1 : A_sh0;
-        float* Aw_sh = buf ? Aw_sh1 : Aw_sh0;
-
-        long long global_q = __ldg(&query_indices[q]);
-        const float* Aw_base = Aw + ((size_t)q * (size_t)Sa);
-        int q_next = q + 1;
-        unsigned long long* A_sh_next = nullptr;
-        const unsigned long long* A_base_next = nullptr;
-        if (q_next < q_end) {
-            A_base_next = A + ((size_t)q_next * (size_t)Sa * (size_t)Wc);
-            A_sh_next = buf ? A_sh0 : A_sh1;
-            cp_async_copy_ull(A_sh_next, A_base_next, Sa * Wc);
-            cp_async_commit();
-        }
-
-        for (int idx = threadIdx.x; idx < Sa; idx += blockDim.x) {
-            Aw_sh[idx] = __ldg(&Aw_base[idx]);
-        }
-        __syncthreads();
-
-        for (int out_idx = warp_id; out_idx < tile_r; out_idx += num_warps) {
-            int r = r_start + out_idx;
-            if (r >= R) continue;
-            long long global_r = __ldg(&key_indices[r]);
-            int sbn = sb_len ? __ldg(&sb_len[r]) : SB;
-            if (sbn <= 0) continue;
-
-            float local = 0.0f;
-            const unsigned long long* b_row =
-                B_sh + (size_t)out_idx * (size_t)SB * (size_t)Wc + (size_t)lane;
-            const float* bw_row = Bw_sh + (size_t)out_idx * (size_t)SB;
-            const unsigned int full_mask = 0xffffffffu;
-
-            float bw_cache[SB];
-            unsigned long long b_cache0[SB];
-            unsigned long long b_cache1[SB];
-            unsigned long long b_cache2[SB];
-            unsigned long long b_cache3[SB];
-            const unsigned long long* b_ptr_init = b_row;
-#pragma unroll
-            for (int j = 0; j < SB; ++j) {
-                bool ok = (j < sbn);
-                bw_cache[j] = ok ? bw_row[j] : 0.0f;
-                b_cache0[j] = ok ? b_ptr_init[0] : 0ull;
-                b_cache1[j] = ok ? b_ptr_init[32] : 0ull;
-                b_cache2[j] = ok ? b_ptr_init[64] : 0ull;
-                b_cache3[j] = ok ? b_ptr_init[96] : 0ull;
-                b_ptr_init += Wc;
-            }
-
-            if (Sa <= 16) {
-                const unsigned long long* a_ptr = A_sh + (size_t)lane;
-#pragma unroll
-                for (int i = 0; i < 16; ++i) {
-                    float aw = 0.0f;
-                    if (i < Sa) {
-                        if (lane == 0) aw = Aw_sh[i];
-                        aw = __shfl_sync(full_mask, aw, 0);
-                        unsigned long long a0 = a_ptr[0];
-                        unsigned long long a1 = a_ptr[32];
-                        unsigned long long a2 = a_ptr[64];
-                        unsigned long long a3 = a_ptr[96];
-#pragma unroll
-                        for (int j = 0; j < SB; ++j) {
-                            int cnt = __popcll(a0 & b_cache0[j]);
-                            cnt += __popcll(a1 & b_cache1[j]);
-                            cnt += __popcll(a2 & b_cache2[j]);
-                            cnt += __popcll(a3 & b_cache3[j]);
-                            local += (float)cnt * aw * bw_cache[j];
-                        }
-                    }
-                    a_ptr += Wc;
-                }
-            } else {
-                const unsigned long long* a_ptr = A_sh + (size_t)lane;
-                for (int i = 0; i < Sa; ++i) {
-                    float aw = 0.0f;
-                    if (lane == 0) aw = Aw_sh[i];
-                    aw = __shfl_sync(full_mask, aw, 0);
-                    unsigned long long a0 = a_ptr[0];
-                    unsigned long long a1 = a_ptr[32];
-                    unsigned long long a2 = a_ptr[64];
-                    unsigned long long a3 = a_ptr[96];
-                    a_ptr += Wc;
-#pragma unroll
-                    for (int j = 0; j < SB; ++j) {
-                        int cnt = __popcll(a0 & b_cache0[j]);
-                        cnt += __popcll(a1 & b_cache1[j]);
-                        cnt += __popcll(a2 & b_cache2[j]);
-                        cnt += __popcll(a3 & b_cache3[j]);
-                        local += (float)cnt * aw * bw_cache[j];
-                    }
-                }
-            }
-
-            local = warp_reduce_sum_float(local);
-            if (lane == 0) {
-                out_global[((size_t)global_q * (size_t)R_total) + (size_t)global_r] = local * scale_inv;
-            }
-        }
-        if (q_next < q_end) {
-            cp_async_wait();
-            cp_async_tail_ull(A_sh_next, A_base_next, Sa * Wc);
-            __syncthreads();
-        }
-    }
-}
-
 template <int SB>
 static inline void launch_w32_sb_kernel(
     const unsigned long long* A,
@@ -1082,74 +724,6 @@ static inline void launch_w128_sb_kernel(
         A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, scale_inv, R_total, out_global);
 }
 
-static inline void launch_w32_sb_var8(
-    const unsigned long long* A,
-    const float* Aw,
-    int Sa,
-    int W,
-    const unsigned long long* B,
-    const float* Bw,
-    int Sb,
-    int R,
-    int Q,
-    int tile_q,
-    int tile_r,
-    const long long* indices_r,
-    const long long* indices_q,
-    const int* sb_len,
-    float scale_inv,
-    int R_total,
-    float* out_global,
-    size_t shared_bytes,
-    dim3 grid_warp,
-    dim3 block,
-    cudaStream_t stream,
-    int max_shared_default)
-{
-    if (shared_bytes > (size_t)max_shared_default) {
-        cudaFuncSetAttribute(
-            popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            (int)shared_bytes);
-    }
-    popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w32_sb_var8<<<grid_warp, block, shared_bytes, stream>>>(
-        A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, sb_len, scale_inv, R_total, out_global);
-}
-
-static inline void launch_w128_sb_var8(
-    const unsigned long long* A,
-    const float* Aw,
-    int Sa,
-    int W,
-    const unsigned long long* B,
-    const float* Bw,
-    int Sb,
-    int R,
-    int Q,
-    int tile_q,
-    int tile_r,
-    const long long* indices_r,
-    const long long* indices_q,
-    const int* sb_len,
-    float scale_inv,
-    int R_total,
-    float* out_global,
-    size_t shared_bytes,
-    dim3 grid_warp,
-    dim3 block,
-    cudaStream_t stream,
-    int max_shared_default)
-{
-    if (shared_bytes > (size_t)max_shared_default) {
-        cudaFuncSetAttribute(
-            popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            (int)shared_bytes);
-    }
-    popcount_weighted_keys_literal_fused_multiq_kernel_warp_out_w128_sb_var8<<<grid_warp, block, shared_bytes, stream>>>(
-        A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r, indices_r, indices_q, sb_len, scale_inv, R_total, out_global);
-}
-
 extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
     const unsigned long long* A,
     const float* Aw,
@@ -1164,7 +738,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
     int r_tile,
     const long long* indices_r,
     const long long* indices_q,
-    const int* sb_len,
     float scale_inv,
     int R_total,
     float* out_global,
@@ -1201,7 +774,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
         int max_shared = (max_shared_optin > max_shared_default) ? max_shared_optin : max_shared_default;
         bool use_w32 = (W == 32 && Sb >= 1 && Sb <= 16);
         bool use_w128 = (W == 128 && Sb >= 1 && Sb <= 8);
-        bool use_sb_len = (sb_len != nullptr && Sb == 8);
         size_t a_word_factor = (use_w32 || use_w128) ? 2u : 1u;
         size_t a_float_factor = (use_w32 || use_w128) ? 2u : 1u;
         int tile_r_eff = tile_r;
@@ -1222,10 +794,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
         } else {
             dim3 grid_warp((R + tile_r_eff - 1) / tile_r_eff, (Q + tile_q - 1) / tile_q);
             if (use_w32) {
-                if (use_sb_len) {
-                    launch_w32_sb_var8(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
-                                       sb_len, scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
-                } else {
                 switch (Sb) {
                     case 1:
                         launch_w32_sb_kernel<1>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
@@ -1293,12 +861,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                                                      scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
                         break;
                 }
-                }
             } else if (use_w128) {
-                if (use_sb_len) {
-                    launch_w128_sb_var8(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
-                                        sb_len, scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
-                } else {
                 switch (Sb) {
                     case 1:
                         launch_w128_sb_kernel<1>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
@@ -1333,7 +896,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                         launch_w128_sb_kernel<8>(A, Aw, Sa, W, B, Bw, Sb, R, Q, tile_q, tile_r_eff, indices_r, indices_q,
                                                      scale_inv, R_total, out_global, shared_bytes, grid_warp, block, stream, max_shared_default);
                         break;
-                }
                 }
             } else {
                 if (shared_bytes > (size_t)max_shared_default) {


### PR DESCRIPTION
keep W32/W128 fast paths and remove unused EWAH buffers