### PR TITLE
TM32 BMMA hot-path specialization

### DIFF
--- a/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
+++ b/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
@@ -1,0 +1,208 @@
+import argparse
+import os
+import subprocess
+import sys
+from typing import Callable, Dict, List
+
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import bsi_ops
+
+
+def _parse_modes(raw: str) -> List[str]:
+    out: List[str] = []
+    for mode in raw.split(","):
+        m = mode.strip().lower()
+        if m:
+            out.append(m)
+    return out
+
+
+def _torch_dtype_from_flag(flag: str) -> torch.dtype:
+    f = flag.strip().lower()
+    if f == "fp16":
+        return torch.float16
+    if f == "bf16":
+        return torch.bfloat16
+    if f == "fp32":
+        return torch.float32
+    raise ValueError(f"Unsupported torch dtype: {flag}")
+
+
+def _time_cuda_ms(fn: Callable[[], None], warmup: int, iters: int) -> float:
+    for _ in range(max(0, warmup)):
+        fn()
+    torch.cuda.synchronize()
+
+    total_ms = 0.0
+    for _ in range(max(1, iters)):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        total_ms += float(start.elapsed_time(end))
+    return total_ms / float(max(1, iters))
+
+
+def _print_row(name: str, avg_ms: float, q: int, r: int) -> None:
+    qps = (q * 1000.0 / avg_ms) if avg_ms > 0.0 else 0.0
+    ns_per_scalar = (avg_ms * 1.0e6 / float(q * r)) if (q > 0 and r > 0 and avg_ms > 0.0) else 0.0
+    us_per_query = (avg_ms * 1000.0 / float(q)) if (q > 0 and avg_ms > 0.0) else 0.0
+    print(
+        f"{name:18s} avg_ms={avg_ms:9.4f}  "
+        f"dot_q_us={us_per_query:8.4f}  dot_s_ns={ns_per_scalar:8.4f}  qps={qps:10.2f}"
+    )
+
+
+def run_kernel_only(args: argparse.Namespace, k_cpu: torch.Tensor, q_fp32: torch.Tensor, torch_dtype: torch.dtype) -> Dict[str, float]:
+    print("\n[Mode] kernel_only")
+    keys_cap, _, _, _, _ = bsi_ops.build_bsi_keys_cuda(
+        k_cpu, args.decimal_places, float(args.compress_threshold)
+    )
+    query_batch = bsi_ops.build_bsi_queries_cuda_batch_packed(
+        q_fp32, args.decimal_places, float(args.compress_threshold)
+    )
+
+    k_torch = k_cpu.to(device="cuda", dtype=torch_dtype, non_blocking=False)
+    q_torch = q_fp32.to(dtype=torch_dtype)
+
+    def run_bsi() -> None:
+        bsi_ops.batch_dot_product_multiquery_cuda_batch_caps(query_batch, keys_cap)
+
+    def run_torch() -> None:
+        torch.matmul(q_torch, k_torch.t())
+
+    bsi_ms = _time_cuda_ms(run_bsi, args.warmup, args.iters)
+    torch_ms = _time_cuda_ms(run_torch, args.warmup, args.iters)
+
+    _print_row("BSI kernel", bsi_ms, args.Q, args.R)
+    _print_row(f"Torch {args.torch_dtype}", torch_ms, args.Q, args.R)
+    speedup = (torch_ms / bsi_ms) if bsi_ms > 0.0 else 0.0
+    print(f"speedup_vs_torch = {speedup:.4f}x")
+    return {"bsi_ms": bsi_ms, "torch_ms": torch_ms, "speedup_vs_torch": speedup}
+
+
+def run_linear_e2e(args: argparse.Namespace, k_cpu: torch.Tensor, q_fp32: torch.Tensor, torch_dtype: torch.dtype) -> Dict[str, float]:
+    print("\n[Mode] linear_e2e")
+    keys_cap, _, _, _, _ = bsi_ops.build_bsi_keys_cuda(
+        k_cpu, args.decimal_places, float(args.compress_threshold)
+    )
+    k_torch = k_cpu.to(device="cuda", dtype=torch_dtype, non_blocking=False)
+    q_torch = q_fp32.to(dtype=torch_dtype)
+
+    def run_bsi() -> None:
+        query_batch = bsi_ops.build_bsi_queries_cuda_batch_packed(
+            q_fp32, args.decimal_places, float(args.compress_threshold)
+        )
+        bsi_ops.batch_dot_product_multiquery_cuda_batch_caps(query_batch, keys_cap)
+
+    def run_torch() -> None:
+        torch.matmul(q_torch, k_torch.t())
+
+    bsi_ms = _time_cuda_ms(run_bsi, args.warmup, args.iters)
+    torch_ms = _time_cuda_ms(run_torch, args.warmup, args.iters)
+
+    _print_row("BSI e2e", bsi_ms, args.Q, args.R)
+    _print_row(f"Torch {args.torch_dtype}", torch_ms, args.Q, args.R)
+    speedup = (torch_ms / bsi_ms) if bsi_ms > 0.0 else 0.0
+    print(f"speedup_vs_torch = {speedup:.4f}x")
+    return {"bsi_ms": bsi_ms, "torch_ms": torch_ms, "speedup_vs_torch": speedup}
+
+
+def run_model_e2e(args: argparse.Namespace) -> None:
+    print("\n[Mode] model_e2e")
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    script = os.path.join(this_dir, "benchmark_performance_bsi.py")
+    cmd = [
+        sys.executable,
+        script,
+        "--model_name", args.model_name,
+        "--datasets", args.dataset,
+        "--split", args.split,
+        "--num_samples", str(args.num_samples),
+        "--max_seq_len", str(args.max_seq_len),
+        "--decimal_places", str(args.decimal_places),
+        "--compress_threshold", str(args.compress_threshold),
+        "--scope", args.scope,
+        "--bsi_device", args.bsi_device,
+    ]
+    env = dict(os.environ)
+    env["BSI_PROFILE"] = "1" if int(args.bsi_profile) != 0 else "0"
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, check=True, env=env)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Apples-to-apples BSI vs Torch timing (kernel_only, linear_e2e, model_e2e)"
+    )
+    parser.add_argument("--modes", type=str, default="kernel_only,linear_e2e",
+                        help="Comma-separated modes: kernel_only,linear_e2e,model_e2e")
+    parser.add_argument("--Q", type=int, default=128, help="Query rows")
+    parser.add_argument("--R", type=int, default=256, help="Key rows / output features")
+    parser.add_argument("--D", type=int, default=2048, help="Input features")
+    parser.add_argument("--decimal_places", type=int, default=2)
+    parser.add_argument("--compress_threshold", type=float, default=0.5)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--torch_dtype", type=str, default="fp16", choices=["fp16", "bf16", "fp32"])
+    parser.add_argument("--bsi_profile", type=int, default=0,
+                        help="Set BSI_PROFILE env (0 recommended for apples-to-apples runtime timing)")
+    parser.add_argument("--model_name", type=str, default="facebook/opt-125m")
+    parser.add_argument("--dataset", type=str, default="lambada")
+    parser.add_argument("--split", type=str, default="validation")
+    parser.add_argument("--num_samples", type=int, default=200)
+    parser.add_argument("--max_seq_len", type=int, default=512)
+    parser.add_argument("--scope", type=str, default="all")
+    parser.add_argument("--bsi_device", type=str, default="cuda")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    os.environ["BSI_PROFILE"] = "1" if int(args.bsi_profile) != 0 else "0"
+    torch_dtype = _torch_dtype_from_flag(args.torch_dtype)
+    modes = _parse_modes(args.modes)
+    allowed = {"kernel_only", "linear_e2e", "model_e2e"}
+    invalid = [m for m in modes if m not in allowed]
+    if invalid:
+        raise ValueError(f"Unsupported mode(s): {invalid}. Allowed: {sorted(allowed)}")
+
+    torch.manual_seed(args.seed)
+    device = torch.device("cuda")
+    k_cpu = torch.randn(args.R, args.D, dtype=torch.float32, device="cpu")
+    q_fp32 = torch.randn(args.Q, args.D, dtype=torch.float32, device=device)
+
+    print("[Config]")
+    print(f"  modes={modes}")
+    print(f"  shape=(Q={args.Q}, R={args.R}, D={args.D})")
+    print(f"  decimal_places={args.decimal_places}  compress_threshold={args.compress_threshold}")
+    print(f"  warmup={args.warmup}  iters={args.iters}")
+    print(f"  torch_dtype={args.torch_dtype}  BSI_PROFILE={os.environ.get('BSI_PROFILE', '0')}")
+
+    results: Dict[str, Dict[str, float]] = {}
+    if "kernel_only" in modes:
+        results["kernel_only"] = run_kernel_only(args, k_cpu, q_fp32, torch_dtype)
+    if "linear_e2e" in modes:
+        results["linear_e2e"] = run_linear_e2e(args, k_cpu, q_fp32, torch_dtype)
+    if "model_e2e" in modes:
+        run_model_e2e(args)
+
+    print("\n[Summary]")
+    for mode in modes:
+        if mode in results:
+            row = results[mode]
+            print(
+                f"  {mode:12s}  bsi_ms={row['bsi_ms']:.4f}  "
+                f"torch_ms={row['torch_ms']:.4f}  speedup_vs_torch={row['speedup_vs_torch']:.4f}x"
+            )
+        elif mode == "model_e2e":
+            print(f"  {mode:12s}  completed (see benchmark_performance_bsi.py output above)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
+++ b/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
@@ -129,6 +129,7 @@ def run_model_e2e(args: argparse.Namespace) -> None:
         "--scope", args.scope,
         "--bsi_device", args.bsi_device,
         "--bsi_profile", str(args.bsi_profile),
+        "--base_dtype", args.base_dtype,
     ]
     env = dict(os.environ)
     env["BSI_PROFILE"] = "1" if int(args.bsi_profile) != 0 else "0"
@@ -160,6 +161,8 @@ def main() -> None:
     parser.add_argument("--max_seq_len", type=int, default=512)
     parser.add_argument("--scope", type=str, default="all")
     parser.add_argument("--bsi_device", type=str, default="cuda")
+    parser.add_argument("--base_dtype", type=str, default="fp16", choices=["fp16", "fp32"],
+                        help="Base model dtype for BSI model in model_e2e (default fp16 for apples-to-apples)")
     args = parser.parse_args()
 
     if not torch.cuda.is_available():

--- a/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
+++ b/bsi_ops/benchmarks/benchmark_apples_to_apples_bsi.py
@@ -128,6 +128,7 @@ def run_model_e2e(args: argparse.Namespace) -> None:
         "--compress_threshold", str(args.compress_threshold),
         "--scope", args.scope,
         "--bsi_device", args.bsi_device,
+        "--bsi_profile", str(args.bsi_profile),
     ]
     env = dict(os.environ)
     env["BSI_PROFILE"] = "1" if int(args.bsi_profile) != 0 else "0"

--- a/bsi_ops/benchmarks/verify_accuracy_bsi.py
+++ b/bsi_ops/benchmarks/verify_accuracy_bsi.py
@@ -100,6 +100,9 @@ class BSIQuantizedLinear(torch.nn.Module):
         self.dot_query_vectors_total = 0
         self.dot_output_elements_total = 0
         self.build_ns_total = 0  # optional: track Python-side build time if desired
+        self.build_quantize_ns_total = 0
+        self.build_pack_ns_total = 0
+        self.build_kernel_ns_total = 0
         self.build_calls = 0
         # optional stats collection flag toggled by helpers
         self.collect_stats = False
@@ -156,6 +159,11 @@ class BSIQuantizedLinear(torch.nn.Module):
                 float(self.query_compress_threshold),
             )
         self.build_ns_total += (time.perf_counter_ns() - t_build0)
+        if hasattr(bsi_ops, "get_last_query_build_profile_cuda"):
+            q_ns, p_ns, t_ns = bsi_ops.get_last_query_build_profile_cuda()
+            self.build_quantize_ns_total += int(q_ns)
+            self.build_pack_ns_total += int(p_ns)
+            self.build_kernel_ns_total += int(t_ns)
         self.build_calls += 1
 
         # Single multi-query call on CUDA to compute all outputs at once
@@ -209,6 +217,9 @@ def reset_bsi_dot_counters(model: nn.Module):
             m.dot_ns_total = 0
             m.dot_calls = 0
             m.build_ns_total = 0
+            m.build_quantize_ns_total = 0
+            m.build_pack_ns_total = 0
+            m.build_kernel_ns_total = 0
             m.build_calls = 0
             m.dot_query_vectors_total = 0
             m.dot_output_elements_total = 0
@@ -225,6 +236,27 @@ def sum_bsi_build_counters(model: nn.Module) -> int:
     for m in model.modules():
         if isinstance(m, BSIQuantizedLinear):
             total += int(m.build_ns_total)
+    return total
+
+def sum_bsi_build_quantize_counters(model: nn.Module) -> int:
+    total = 0
+    for m in model.modules():
+        if isinstance(m, BSIQuantizedLinear):
+            total += int(getattr(m, "build_quantize_ns_total", 0))
+    return total
+
+def sum_bsi_build_pack_counters(model: nn.Module) -> int:
+    total = 0
+    for m in model.modules():
+        if isinstance(m, BSIQuantizedLinear):
+            total += int(getattr(m, "build_pack_ns_total", 0))
+    return total
+
+def sum_bsi_build_kernel_counters(model: nn.Module) -> int:
+    total = 0
+    for m in model.modules():
+        if isinstance(m, BSIQuantizedLinear):
+            total += int(getattr(m, "build_kernel_ns_total", 0))
     return total
 
 def sum_bsi_dot_query_vectors(model: nn.Module) -> int:

--- a/bsi_ops/benchmarks/verify_accuracy_bsi.py
+++ b/bsi_ops/benchmarks/verify_accuracy_bsi.py
@@ -121,7 +121,10 @@ class BSIQuantizedLinear(torch.nn.Module):
         original_shape = x.shape
         if len(x.shape) > 2:
             x = x.view(-1, x.shape[-1])
-        x = x.to(torch.float32)
+        # Keep activations in their native dtype for query build by default.
+        # The CUDA fixed-bit quant kernels accept fp16/bf16/fp32 directly.
+        if os.getenv("BSI_QUERY_FP32", "0") != "0":
+            x = x.to(torch.float32)
 
         dot_ns_this_forward = 0
         

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels.cu
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels.cu
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "bsi_cuda_kernels_utils.cuh"
+#include "bsi_cuda_kernels_quant.cuh"
 #include "bsi_cuda_kernels_pack.cuh"
 #include "bsi_cuda_kernels_dot.cuh"
 #include "bsi_cuda_kernels_ewah.cuh"

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -1065,7 +1065,7 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel(
 // BMMA TC variant: 8 warps per block (32x32 output tile).
 // This reuses the same B tile across 2x as many query rows (vs TM=16), which
 // cuts B global->shared traffic per output.
-template <int SB, int TNV>
+template <int SB>
 __device__ __forceinline__ void bsi_bmma_tm32_accum_sa7_sb_hot(
     const uint32_t* __restrict__ A_bits,
     const float* __restrict__ Aw_tile,
@@ -1400,7 +1400,7 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
             // Sb==7/6 are hot configurations (fixed-bit weights) and tend to regress if the compiler
             // can't specialize away the tail checks. Keep explicit fast paths.
             if (Sa == 7 && Sb == 7) {
-                bsi_bmma_tm32_accum_sa7_sb_hot<7, 32>(
+                bsi_bmma_tm32_accum_sa7_sb_hot<7>(
                     A_bits,
                     Aw_tile,
                     b_col_base,
@@ -1417,7 +1417,7 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
                     acc10,
                     acc11);
             } else if (Sa == 7 && Sb == 6) {
-                bsi_bmma_tm32_accum_sa7_sb_hot<6, 32>(
+                bsi_bmma_tm32_accum_sa7_sb_hot<6>(
                     A_bits,
                     Aw_tile,
                     b_col_base,
@@ -2157,413 +2157,10 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
 #endif
 }
 
-// BMMA TC hot kernel: TM32 x TN64 for fixed Sa=7 and Sb in {6,7}.
-// Designed for large-R layers where wider N-tiling improves B reuse and reduces block scheduling overhead.
-template <int SB>
-__global__ __launch_bounds__(512)
-void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32_tn64_hot(
-    const unsigned long long* __restrict__ A,    // [Q, 7, W64]
-    const float* __restrict__ Aw,                // [Q, 7]
-    const float* __restrict__ A_chunk_scales,    // [Q, chunks] or nullptr
-    int A_scale_stride,                          // chunks (W64/4) or 0
-    int W64,
-    const unsigned long long* __restrict__ B,    // [R, SB, W64]
-    const float* __restrict__ Bw,                // [R, SB]
-    int R,
-    int Q,
-    const long long* __restrict__ key_indices,   // [R]
-    const long long* __restrict__ query_indices, // [Q]
-    float scale_inv,
-    int R_total,
-    float* __restrict__ out_global,
-    int use_cpasync)
-{
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-    static_assert(SB == 6 || SB == 7, "SB must be 6 or 7");
-    constexpr int SA = 7;
-    constexpr int TM_TOTAL = 32;
-    constexpr int TM = 16;
-    constexpr int TN = 64;
-    constexpr int WARPS_PER_QTILE = 8; // 64 cols / 8 cols per warp
-    constexpr int QTILES = TM_TOTAL / TM; // 2
-    constexpr int K_BITS = 256;
-    constexpr int K_WORDS64 = K_BITS / 64;   // 4
-    constexpr int K_WORDS32 = K_BITS / 32;   // 8
-    constexpr int K_STRIDE32 = K_WORDS32 + 4; // 12 (padding)
-
-    if (blockDim.x != (WARPS_PER_QTILE * QTILES * 32)) return; // 512
-    const int lane = threadIdx.x & 31;
-    const int warp_id = threadIdx.x >> 5;          // 0..15
-    const int q_tile_id = warp_id >> 3;            // /8 -> 0..1
-    const int warp_in_tile = warp_id & (WARPS_PER_QTILE - 1); // 0..7
-
-    const int q0 = blockIdx.y * TM_TOTAL;
-    const int r0 = blockIdx.x * TN;
-    const bool full_q_tile = (q0 + TM_TOTAL) <= Q;
-    const bool full_r_tile = (r0 + TN) <= R;
-
-    extern __shared__ unsigned char smem_raw[];
-    uintptr_t p = reinterpret_cast<uintptr_t>(smem_raw);
-    p = (p + 15u) & ~uintptr_t(15u);
-
-    const int stages = (use_cpasync != 0) ? 2 : 1;
-    const size_t A_words = (size_t)SA * (size_t)TM_TOTAL * (size_t)K_STRIDE32;
-    const size_t B_words = (size_t)SB * (size_t)TN * (size_t)K_STRIDE32;
-
-    auto* A_bits0 = reinterpret_cast<uint32_t*>(p); // [stages, SA, TM_TOTAL, K]
-    p += (size_t)stages * A_words * sizeof(uint32_t);
-    auto* B_bits0 = reinterpret_cast<uint32_t*>(p); // [stages, SB, TN, K]
-    p += (size_t)stages * B_words * sizeof(uint32_t);
-    auto* Aw_tile = reinterpret_cast<float*>(p);    // [TM_TOTAL, SA]
-    p += (size_t)TM_TOTAL * (size_t)SA * sizeof(float);
-    auto* Bw_tile = reinterpret_cast<float*>(p);    // [TN, SB]
-    p += (size_t)TN * (size_t)SB * sizeof(float);
-    (void)p;
-
-    if (full_q_tile) {
-        for (int idx = threadIdx.x; idx < TM_TOTAL * SA; idx += blockDim.x) {
-            const int m = idx / SA;
-            const int i = idx - m * SA;
-            const int q = q0 + m;
-            Aw_tile[(size_t)m * (size_t)SA + (size_t)i] = __ldg(&Aw[(size_t)q * (size_t)SA + (size_t)i]);
-        }
-    } else {
-        for (int idx = threadIdx.x; idx < TM_TOTAL * SA; idx += blockDim.x) {
-            const int m = idx / SA;
-            const int i = idx - m * SA;
-            const int q = q0 + m;
-            Aw_tile[(size_t)m * (size_t)SA + (size_t)i] =
-                (q < Q) ? __ldg(&Aw[(size_t)q * (size_t)SA + (size_t)i]) : 0.0f;
-        }
-    }
-    if (full_r_tile) {
-        for (int idx = threadIdx.x; idx < TN * SB; idx += blockDim.x) {
-            const int n = idx / SB;
-            const int j = idx - n * SB;
-            const int r = r0 + n;
-            Bw_tile[(size_t)n * (size_t)SB + (size_t)j] = __ldg(&Bw[(size_t)r * (size_t)SB + (size_t)j]);
-        }
-    } else {
-        for (int idx = threadIdx.x; idx < TN * SB; idx += blockDim.x) {
-            const int n = idx / SB;
-            const int j = idx - n * SB;
-            const int r = r0 + n;
-            Bw_tile[(size_t)n * (size_t)SB + (size_t)j] =
-                (r < R) ? __ldg(&Bw[(size_t)r * (size_t)SB + (size_t)j]) : 0.0f;
-        }
-    }
-    __syncthreads();
-
-    const int groupID = lane >> 2;            // 0..7
-    const int threadID = lane & 3;            // 0..3
-    const int row0 = groupID;                 // 0..7
-    const int row1 = groupID + 8;             // 8..15
-    const int col_base = warp_in_tile * 8;    // 0..56
-    const int col0 = col_base + threadID * 2; // even
-    const int col1 = col0 + 1;                // odd
-    const int m0 = q_tile_id * TM + row0;     // 0..31
-    const int m1 = q_tile_id * TM + row1;     // 0..31
-
-    float acc00 = 0.0f, acc01 = 0.0f, acc10 = 0.0f, acc11 = 0.0f;
-    const float* bw_col0 = Bw_tile + (size_t)col0 * (size_t)SB;
-    const float* bw_col1 = Bw_tile + (size_t)col1 * (size_t)SB;
-
-    const int chunks = W64 / K_WORDS64;
-    const bool can_cpasync = (use_cpasync != 0) && full_q_tile && full_r_tile && (chunks > 1);
-
-    if (can_cpasync) {
-        uint32_t* A_bits = A_bits0;
-        uint32_t* B_bits = B_bits0;
-        constexpr int K_WORDS64_16B = K_WORDS64 / 2; // 2
-        for (int idx = threadIdx.x; idx < TM_TOTAL * SA * K_WORDS64_16B; idx += blockDim.x) {
-            int t = idx;
-            const int w64_pair = t & (K_WORDS64_16B - 1);
-            t >>= 1;
-            const int m = t & (TM_TOTAL - 1);
-            const int i = t >> 5; // /32
-
-            const int q = q0 + m;
-            const unsigned long long* a_slice = A + ((size_t)q * (size_t)SA + (size_t)i) * (size_t)W64;
-            const int w64_i = w64_pair << 1;
-            const int base = ((i * TM_TOTAL + m) * K_STRIDE32) + (w64_i << 1);
-            bsi_cp_async_cg_16B(A_bits + base, &a_slice[(size_t)w64_i]);
-        }
-        for (int idx = threadIdx.x; idx < TN * SB * K_WORDS64_16B; idx += blockDim.x) {
-            int t = idx;
-            const int w64_pair = t & (K_WORDS64_16B - 1);
-            t >>= 1;
-            const int n = t & (TN - 1);
-            const int j = t >> 6; // /64
-
-            const int r = r0 + n;
-            const unsigned long long* b_slice = B + ((size_t)r * (size_t)SB + (size_t)j) * (size_t)W64;
-            const int w64_i = w64_pair << 1;
-            const int base = ((j * TN + n) * K_STRIDE32) + (w64_i << 1);
-            bsi_cp_async_cg_16B(B_bits + base, &b_slice[(size_t)w64_i]);
-        }
-        bsi_cp_async_commit_group();
-        bsi_cp_async_wait_all();
-        __syncthreads();
-    }
-
-    int stage = 0;
-    for (int chunk = 0; chunk < chunks; ++chunk) {
-        uint32_t* A_bits = (stage == 0) ? A_bits0 : (A_bits0 + A_words);
-        uint32_t* B_bits = (stage == 0) ? B_bits0 : (B_bits0 + B_words);
-
-        if (!can_cpasync) {
-            if (full_q_tile) {
-                for (int idx = threadIdx.x; idx < TM_TOTAL * SA * K_WORDS64; idx += blockDim.x) {
-                    int t = idx;
-                    const int w64_i = t & (K_WORDS64 - 1);
-                    t >>= 2;
-                    const int m = t & (TM_TOTAL - 1);
-                    const int i = t >> 5; // /32
-
-                    const int q = q0 + m;
-                    const unsigned long long* a_slice = A + ((size_t)q * (size_t)SA + (size_t)i) * (size_t)W64;
-                    const unsigned long long w64 =
-                        __ldg(&a_slice[(size_t)chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-                    const uint32_t lo = static_cast<uint32_t>(w64);
-                    const uint32_t hi = static_cast<uint32_t>(w64 >> 32);
-                    const int base = ((i * TM_TOTAL + m) * K_STRIDE32) + (w64_i << 1);
-                    A_bits[base] = lo;
-                    A_bits[base + 1] = hi;
-                }
-            } else {
-                for (int idx = threadIdx.x; idx < TM_TOTAL * SA * K_WORDS64; idx += blockDim.x) {
-                    int t = idx;
-                    const int w64_i = t & (K_WORDS64 - 1);
-                    t >>= 2;
-                    const int m = t & (TM_TOTAL - 1);
-                    const int i = t >> 5; // /32
-
-                    uint32_t lo = 0u, hi = 0u;
-                    const int q = q0 + m;
-                    if (q < Q) {
-                        const unsigned long long* a_slice = A + ((size_t)q * (size_t)SA + (size_t)i) * (size_t)W64;
-                        const unsigned long long w64 =
-                            __ldg(&a_slice[(size_t)chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-                        lo = static_cast<uint32_t>(w64);
-                        hi = static_cast<uint32_t>(w64 >> 32);
-                    }
-                    const int base = ((i * TM_TOTAL + m) * K_STRIDE32) + (w64_i << 1);
-                    A_bits[base] = lo;
-                    A_bits[base + 1] = hi;
-                }
-            }
-
-            if (full_r_tile) {
-                for (int idx = threadIdx.x; idx < TN * SB * K_WORDS64; idx += blockDim.x) {
-                    int t = idx;
-                    const int w64_i = t & (K_WORDS64 - 1);
-                    t >>= 2;
-                    const int n = t & (TN - 1);
-                    const int j = t >> 6; // /64
-
-                    const int r = r0 + n;
-                    const unsigned long long* b_slice = B + ((size_t)r * (size_t)SB + (size_t)j) * (size_t)W64;
-                    const unsigned long long w64 =
-                        __ldg(&b_slice[(size_t)chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-                    const uint32_t lo = static_cast<uint32_t>(w64);
-                    const uint32_t hi = static_cast<uint32_t>(w64 >> 32);
-                    const int base = ((j * TN + n) * K_STRIDE32) + (w64_i << 1);
-                    B_bits[base] = lo;
-                    B_bits[base + 1] = hi;
-                }
-            } else {
-                for (int idx = threadIdx.x; idx < TN * SB * K_WORDS64; idx += blockDim.x) {
-                    int t = idx;
-                    const int w64_i = t & (K_WORDS64 - 1);
-                    t >>= 2;
-                    const int n = t & (TN - 1);
-                    const int j = t >> 6; // /64
-
-                    uint32_t lo = 0u, hi = 0u;
-                    const int r = r0 + n;
-                    if (r < R) {
-                        const unsigned long long* b_slice = B + ((size_t)r * (size_t)SB + (size_t)j) * (size_t)W64;
-                        const unsigned long long w64 =
-                            __ldg(&b_slice[(size_t)chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-                        lo = static_cast<uint32_t>(w64);
-                        hi = static_cast<uint32_t>(w64 >> 32);
-                    }
-                    const int base = ((j * TN + n) * K_STRIDE32) + (w64_i << 1);
-                    B_bits[base] = lo;
-                    B_bits[base + 1] = hi;
-                }
-            }
-            __syncthreads();
-        } else if (chunk + 1 < chunks) {
-            const int next_stage = stage ^ 1;
-            uint32_t* A_bits_next = (next_stage == 0) ? A_bits0 : (A_bits0 + A_words);
-            uint32_t* B_bits_next = (next_stage == 0) ? B_bits0 : (B_bits0 + B_words);
-            const int next_chunk = chunk + 1;
-            constexpr int K_WORDS64_16B = K_WORDS64 / 2; // 2
-            for (int idx = threadIdx.x; idx < TM_TOTAL * SA * K_WORDS64_16B; idx += blockDim.x) {
-                int t = idx;
-                const int w64_pair = t & (K_WORDS64_16B - 1);
-                t >>= 1;
-                const int m = t & (TM_TOTAL - 1);
-                const int i = t >> 5; // /32
-
-                const int q = q0 + m;
-                const unsigned long long* a_slice = A + ((size_t)q * (size_t)SA + (size_t)i) * (size_t)W64;
-                const int w64_i = w64_pair << 1;
-                const int base = ((i * TM_TOTAL + m) * K_STRIDE32) + (w64_i << 1);
-                bsi_cp_async_cg_16B(
-                    A_bits_next + base,
-                    &a_slice[(size_t)next_chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-            }
-            for (int idx = threadIdx.x; idx < TN * SB * K_WORDS64_16B; idx += blockDim.x) {
-                int t = idx;
-                const int w64_pair = t & (K_WORDS64_16B - 1);
-                t >>= 1;
-                const int n = t & (TN - 1);
-                const int j = t >> 6; // /64
-
-                const int r = r0 + n;
-                const unsigned long long* b_slice = B + ((size_t)r * (size_t)SB + (size_t)j) * (size_t)W64;
-                const int w64_i = w64_pair << 1;
-                const int base = ((j * TN + n) * K_STRIDE32) + (w64_i << 1);
-                bsi_cp_async_cg_16B(
-                    B_bits_next + base,
-                    &b_slice[(size_t)next_chunk * (size_t)K_WORDS64 + (size_t)w64_i]);
-            }
-            bsi_cp_async_commit_group();
-        }
-
-        const bool use_chunk_scale = (A_chunk_scales != nullptr) && (A_scale_stride > 0);
-        float qscale_m0 = 1.0f;
-        float qscale_m1 = 1.0f;
-        if (use_chunk_scale) {
-            if (threadID == 0) {
-                const int q_m0 = q0 + m0;
-                const int q_m1 = q0 + m1;
-                if (full_q_tile) {
-                    qscale_m0 = __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk]);
-                    qscale_m1 = __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk]);
-                } else {
-                    qscale_m0 = (q_m0 < Q)
-                        ? __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk])
-                        : 0.0f;
-                    qscale_m1 = (q_m1 < Q)
-                        ? __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk])
-                        : 0.0f;
-                }
-            }
-            qscale_m0 = __shfl_sync(0xffffffff, qscale_m0, lane & ~3);
-            qscale_m1 = __shfl_sync(0xffffffff, qscale_m1, lane & ~3);
-        }
-
-        const uint32_t* b_col_base = B_bits + (col_base + groupID) * K_STRIDE32;
-        bsi_bmma_tm32_accum_sa7_sb_hot<SB, TN>(
-            A_bits,
-            Aw_tile,
-            b_col_base,
-            bw_col0,
-            bw_col1,
-            threadID,
-            m0,
-            m1,
-            use_chunk_scale,
-            qscale_m0,
-            qscale_m1,
-            acc00,
-            acc01,
-            acc10,
-            acc11);
-
-        if (can_cpasync && (chunk + 1 < chunks)) {
-            bsi_cp_async_wait_all();
-        }
-        __syncthreads();
-        if (can_cpasync) stage ^= 1;
-    }
-
-    const int q_out0 = q0 + m0;
-    const int q_out1 = q0 + m1;
-    const int r_out0 = r0 + col0;
-    const int r_out1 = r0 + col1;
-
-    const bool identity_q = (query_indices == nullptr);
-    const bool identity_r = (key_indices == nullptr);
-    if (full_q_tile && full_r_tile && identity_q && identity_r) {
-        out_global[(size_t)q_out0 * (size_t)R_total + (size_t)r_out0] = acc00 * scale_inv;
-        out_global[(size_t)q_out0 * (size_t)R_total + (size_t)r_out1] = acc01 * scale_inv;
-        out_global[(size_t)q_out1 * (size_t)R_total + (size_t)r_out0] = acc10 * scale_inv;
-        out_global[(size_t)q_out1 * (size_t)R_total + (size_t)r_out1] = acc11 * scale_inv;
-    } else if (full_q_tile && full_r_tile) {
-        long long gq0 = 0, gq1 = 0;
-        if (threadID == 0) {
-            gq0 = bsi_load_index_or_identity(query_indices, q_out0);
-            gq1 = bsi_load_index_or_identity(query_indices, q_out1);
-        }
-        gq0 = __shfl_sync(0xffffffff, gq0, lane & ~3);
-        gq1 = __shfl_sync(0xffffffff, gq1, lane & ~3);
-
-        long long gr0 = 0, gr1 = 0;
-        if (groupID == 0) {
-            gr0 = bsi_load_index_or_identity(key_indices, r_out0);
-            gr1 = bsi_load_index_or_identity(key_indices, r_out1);
-        }
-        gr0 = __shfl_sync(0xffffffff, gr0, threadID);
-        gr1 = __shfl_sync(0xffffffff, gr1, threadID);
-
-        out_global[(size_t)gq0 * (size_t)R_total + (size_t)gr0] = acc00 * scale_inv;
-        out_global[(size_t)gq0 * (size_t)R_total + (size_t)gr1] = acc01 * scale_inv;
-        out_global[(size_t)gq1 * (size_t)R_total + (size_t)gr0] = acc10 * scale_inv;
-        out_global[(size_t)gq1 * (size_t)R_total + (size_t)gr1] = acc11 * scale_inv;
-    } else if (identity_q && identity_r) {
-        if (q_out0 < Q && r_out0 < R) out_global[(size_t)q_out0 * (size_t)R_total + (size_t)r_out0] = acc00 * scale_inv;
-        if (q_out0 < Q && r_out1 < R) out_global[(size_t)q_out0 * (size_t)R_total + (size_t)r_out1] = acc01 * scale_inv;
-        if (q_out1 < Q && r_out0 < R) out_global[(size_t)q_out1 * (size_t)R_total + (size_t)r_out0] = acc10 * scale_inv;
-        if (q_out1 < Q && r_out1 < R) out_global[(size_t)q_out1 * (size_t)R_total + (size_t)r_out1] = acc11 * scale_inv;
-    } else {
-        long long gq0 = 0, gq1 = 0;
-        if (threadID == 0) {
-            if (q_out0 < Q) gq0 = bsi_load_index_or_identity(query_indices, q_out0);
-            if (q_out1 < Q) gq1 = bsi_load_index_or_identity(query_indices, q_out1);
-        }
-        gq0 = __shfl_sync(0xffffffff, gq0, lane & ~3);
-        gq1 = __shfl_sync(0xffffffff, gq1, lane & ~3);
-
-        long long gr0 = 0, gr1 = 0;
-        if (groupID == 0) {
-            if (r_out0 < R) gr0 = bsi_load_index_or_identity(key_indices, r_out0);
-            if (r_out1 < R) gr1 = bsi_load_index_or_identity(key_indices, r_out1);
-        }
-        gr0 = __shfl_sync(0xffffffff, gr0, threadID);
-        gr1 = __shfl_sync(0xffffffff, gr1, threadID);
-
-        if (q_out0 < Q && r_out0 < R) out_global[(size_t)gq0 * (size_t)R_total + (size_t)gr0] = acc00 * scale_inv;
-        if (q_out0 < Q && r_out1 < R) out_global[(size_t)gq0 * (size_t)R_total + (size_t)gr1] = acc01 * scale_inv;
-        if (q_out1 < Q && r_out0 < R) out_global[(size_t)gq1 * (size_t)R_total + (size_t)gr0] = acc10 * scale_inv;
-        if (q_out1 < Q && r_out1 < R) out_global[(size_t)gq1 * (size_t)R_total + (size_t)gr1] = acc11 * scale_inv;
-    }
-#else
-    (void)A;
-    (void)Aw;
-    (void)A_chunk_scales;
-    (void)A_scale_stride;
-    (void)W64;
-    (void)B;
-    (void)Bw;
-    (void)R;
-    (void)Q;
-    (void)key_indices;
-    (void)query_indices;
-    (void)scale_inv;
-    (void)R_total;
-    (void)out_global;
-    (void)use_cpasync;
-#endif
-}
-
 // Hot fixed-bit specialization for TM32: Sa==7 with Sb in {6,7}.
 // This keeps the BMMA math identical but makes Sa/Sb compile-time constants and
 // applies chunk qscale once per row per chunk (outside the inner i loop).
-template <int SB, int TNV>
+template <int SB>
 __device__ __forceinline__ void bsi_bmma_tm32_accum_sa7_sb_hot(
     const uint32_t* __restrict__ A_bits,
     const float* __restrict__ Aw_tile,
@@ -2585,8 +2182,9 @@ __device__ __forceinline__ void bsi_bmma_tm32_accum_sa7_sb_hot(
     static_assert(SB == 6 || SB == 7, "SB must be 6 or 7");
     constexpr int SA = 7;
     constexpr int TM_TOTAL = 32;
+    constexpr int TN = 32;
     constexpr int K_STRIDE32 = 12;
-    const int b_slice_stride = TNV * K_STRIDE32;
+    const int b_slice_stride = TN * K_STRIDE32;
 
     uint32_t b0_cache[SB];
     uint32_t b1_cache[SB];
@@ -2833,103 +2431,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                 ? TcTmMode::TM16
                 : (cached_tc_tm_mode == 32 ? TcTmMode::TM32 : TcTmMode::Auto);
 
-            // Optional wider-N hot path (default on): TM32xTN64 specialized for Sa=7,Sb=6/7.
-            // This targets large-R layers where 64-column tiling improves B reuse.
-            static int cached_use_tn64_hot = -1;
-            if (cached_use_tn64_hot < 0) {
-                int v = 1;
-                if (const char* s = getenv("BSI_TC_TN64")) {
-                    v = (atoi(s) != 0) ? 1 : 0;
-                }
-                cached_use_tn64_hot = v;
-            }
-
-            auto try_tm32_tn64_hot = [&]() -> bool {
-                if (cached_use_tn64_hot == 0) return false;
-                if (!(Sa == 7 && (Sb == 6 || Sb == 7))) return false;
-                // Avoid over-tiling very small R.
-                if (R < 512) return false;
-
-                constexpr int TM_TOTAL = 32;
-                constexpr int TN = 64;
-                dim3 block_tc(512, 1, 1);
-                dim3 grid_tc((R + TN - 1) / TN, (Q + TM_TOTAL - 1) / TM_TOTAL, 1);
-
-                int use_cpasync_hot = use_cpasync;
-                const int stages = use_cpasync_hot ? 2 : 1;
-                size_t shared_bytes =
-                    16u +
-                    (size_t)stages * (size_t)Sa * (size_t)TM_TOTAL * (size_t)K_STRIDE32 * sizeof(uint32_t) +
-                    (size_t)stages * (size_t)Sb * (size_t)TN * (size_t)K_STRIDE32 * sizeof(uint32_t) +
-                    (size_t)TM_TOTAL * (size_t)Sa * sizeof(float) +
-                    (size_t)TN * (size_t)Sb * sizeof(float);
-
-                if (shared_bytes > (size_t)max_shared && use_cpasync_hot) {
-                    use_cpasync_hot = 0;
-                    shared_bytes =
-                        16u +
-                        (size_t)Sa * (size_t)TM_TOTAL * (size_t)K_STRIDE32 * sizeof(uint32_t) +
-                        (size_t)Sb * (size_t)TN * (size_t)K_STRIDE32 * sizeof(uint32_t) +
-                        (size_t)TM_TOTAL * (size_t)Sa * sizeof(float) +
-                        (size_t)TN * (size_t)Sb * sizeof(float);
-                }
-                if (shared_bytes > (size_t)max_shared) return false;
-
-                if (Sb == 6) {
-                    static size_t configured_shared_tn64_sb6 = 0;
-                    if (shared_bytes > (size_t)max_shared_default && shared_bytes > configured_shared_tn64_sb6) {
-                        cudaFuncSetAttribute(
-                            popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32_tn64_hot<6>,
-                            cudaFuncAttributeMaxDynamicSharedMemorySize,
-                            (int)shared_bytes);
-                        configured_shared_tn64_sb6 = shared_bytes;
-                    }
-                    popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32_tn64_hot<6><<<grid_tc, block_tc, shared_bytes, stream>>>(
-                        A,
-                        Aw,
-                        A_chunk_scales,
-                        A_scale_stride,
-                        W,
-                        B,
-                        Bw,
-                        R,
-                        Q,
-                        indices_r,
-                        indices_q,
-                        scale_inv,
-                        R_total,
-                        out_global,
-                        use_cpasync_hot);
-                    return true;
-                }
-
-                static size_t configured_shared_tn64_sb7 = 0;
-                if (shared_bytes > (size_t)max_shared_default && shared_bytes > configured_shared_tn64_sb7) {
-                    cudaFuncSetAttribute(
-                        popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32_tn64_hot<7>,
-                        cudaFuncAttributeMaxDynamicSharedMemorySize,
-                        (int)shared_bytes);
-                    configured_shared_tn64_sb7 = shared_bytes;
-                }
-                popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32_tn64_hot<7><<<grid_tc, block_tc, shared_bytes, stream>>>(
-                    A,
-                    Aw,
-                    A_chunk_scales,
-                    A_scale_stride,
-                    W,
-                    B,
-                    Bw,
-                    R,
-                    Q,
-                    indices_r,
-                    indices_q,
-                    scale_inv,
-                    R_total,
-                    out_global,
-                    use_cpasync_hot);
-                return true;
-            };
-
             auto try_tm32 = [&]() -> bool {
                 constexpr int TM_TOTAL = 32;
                 constexpr int TN = 32;
@@ -3034,15 +2535,12 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
             bool launched = false;
             if (tc_tm_mode == TcTmMode::TM16) {
                 launched = try_tm16();
-                if (!launched) launched = try_tm32_tn64_hot();
                 if (!launched) launched = try_tm32();
             } else if (tc_tm_mode == TcTmMode::TM32) {
-                launched = try_tm32_tn64_hot();
-                if (!launched) launched = try_tm32();
+                launched = try_tm32();
                 if (!launched) launched = try_tm16();
             } else {
-                launched = try_tm32_tn64_hot();
-                if (!launched) launched = try_tm32();
+                launched = try_tm32();
                 if (!launched) launched = try_tm16();
             }
             if (launched) return;

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_dot.cuh
@@ -741,8 +741,7 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel(
     const long long* __restrict__ query_indices, // [Q]
     float scale_inv,
     int R_total,
-    float* __restrict__ out_global,
-    int use_qscale_shared)
+    float* __restrict__ out_global)
 {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     constexpr int TM = 16;
@@ -780,8 +779,6 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel(
     p += (size_t)TM * (size_t)Sa * sizeof(float);
     auto* Bw_tile = reinterpret_cast<float*>(p);   // [TN, Sb]
     p += (size_t)TN * (size_t)Sb * sizeof(float);
-    auto* qscale_tile = reinterpret_cast<float*>(p); // [TM]
-    p += (size_t)TM * sizeof(float);
     (void)p;
 
     // Load all slice weights for the tile.
@@ -877,37 +874,19 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel(
         float qscale_row0 = 1.0f;
         float qscale_row1 = 1.0f;
         if (use_chunk_scale) {
-            if (use_qscale_shared != 0) {
-                if (full_q_tile) {
-                    for (int m = threadIdx.x; m < TM; m += blockDim.x) {
-                        qscale_tile[m] = __ldg(&A_chunk_scales[(size_t)(q0 + m) * (size_t)A_scale_stride + (size_t)chunk]);
-                    }
-                } else {
-                    for (int m = threadIdx.x; m < TM; m += blockDim.x) {
-                        const int q_row = q0 + m;
-                        qscale_tile[m] = (q_row < Q)
-                            ? __ldg(&A_chunk_scales[(size_t)q_row * (size_t)A_scale_stride + (size_t)chunk])
-                            : 0.0f;
-                    }
-                }
-                __syncthreads();
-                qscale_row0 = qscale_tile[row0];
-                qscale_row1 = qscale_tile[row1];
-            } else {
-                // Each 4-lane group shares the same query rows (row0/row1). Broadcast to reduce redundant loads.
-                if (threadID == 0) {
-                    const int q_row0 = q0 + row0;
-                    const int q_row1 = q0 + row1;
-                    qscale_row0 = (q_row0 < Q)
-                        ? __ldg(&A_chunk_scales[(size_t)q_row0 * (size_t)A_scale_stride + (size_t)chunk])
-                        : 0.0f;
-                    qscale_row1 = (q_row1 < Q)
-                        ? __ldg(&A_chunk_scales[(size_t)q_row1 * (size_t)A_scale_stride + (size_t)chunk])
-                        : 0.0f;
-                }
-                qscale_row0 = __shfl_sync(0xffffffff, qscale_row0, lane & ~3);
-                qscale_row1 = __shfl_sync(0xffffffff, qscale_row1, lane & ~3);
+            // Each 4-lane group shares the same query rows (row0/row1). Broadcast to reduce redundant loads.
+            if (threadID == 0) {
+                const int q_row0 = q0 + row0;
+                const int q_row1 = q0 + row1;
+                qscale_row0 = (q_row0 < Q)
+                    ? __ldg(&A_chunk_scales[(size_t)q_row0 * (size_t)A_scale_stride + (size_t)chunk])
+                    : 0.0f;
+                qscale_row1 = (q_row1 < Q)
+                    ? __ldg(&A_chunk_scales[(size_t)q_row1 * (size_t)A_scale_stride + (size_t)chunk])
+                    : 0.0f;
             }
+            qscale_row0 = __shfl_sync(0xffffffff, qscale_row0, lane & ~3);
+            qscale_row1 = __shfl_sync(0xffffffff, qscale_row1, lane & ~3);
         }
 
         // For each slice pair (i,j), compute 16x8 popcounts for this 256-bit chunk and
@@ -1080,7 +1059,6 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel(
     (void)scale_inv;
     (void)R_total;
     (void)out_global;
-    (void)use_qscale_shared;
 #endif
 }
 
@@ -1105,8 +1083,7 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
     float scale_inv,
     int R_total,
     float* __restrict__ out_global,
-    int use_cpasync,
-    int use_qscale_shared)
+    int use_cpasync)
 {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     constexpr int TM_TOTAL = 32;
@@ -1149,8 +1126,6 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
     p += (size_t)TM_TOTAL * (size_t)Sa * sizeof(float);
     auto* Bw_tile = reinterpret_cast<float*>(p);   // [TN, Sb]
     p += (size_t)TN * (size_t)Sb * sizeof(float);
-    auto* qscale_tile = reinterpret_cast<float*>(p); // [TM_TOTAL]
-    p += (size_t)TM_TOTAL * sizeof(float);
     (void)p;
 
     if (full_q_tile) {
@@ -1380,42 +1355,24 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
         float qscale_m0 = 1.0f;
         float qscale_m1 = 1.0f;
         if (use_chunk_scale) {
-            if (use_qscale_shared != 0) {
+            // Each 4-lane group shares the same query rows (m0/m1). Broadcast to reduce redundant loads.
+            if (threadID == 0) {
+                const int q_m0 = q0 + m0;
+                const int q_m1 = q0 + m1;
                 if (full_q_tile) {
-                    for (int m = threadIdx.x; m < TM_TOTAL; m += blockDim.x) {
-                        qscale_tile[m] = __ldg(&A_chunk_scales[(size_t)(q0 + m) * (size_t)A_scale_stride + (size_t)chunk]);
-                    }
+                    qscale_m0 = __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk]);
+                    qscale_m1 = __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk]);
                 } else {
-                    for (int m = threadIdx.x; m < TM_TOTAL; m += blockDim.x) {
-                        const int q_m = q0 + m;
-                        qscale_tile[m] = (q_m < Q)
-                            ? __ldg(&A_chunk_scales[(size_t)q_m * (size_t)A_scale_stride + (size_t)chunk])
-                            : 0.0f;
-                    }
+                    qscale_m0 = (q_m0 < Q)
+                        ? __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk])
+                        : 0.0f;
+                    qscale_m1 = (q_m1 < Q)
+                        ? __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk])
+                        : 0.0f;
                 }
-                __syncthreads();
-                qscale_m0 = qscale_tile[m0];
-                qscale_m1 = qscale_tile[m1];
-            } else {
-                // Each 4-lane group shares the same query rows (m0/m1). Broadcast to reduce redundant loads.
-                if (threadID == 0) {
-                    const int q_m0 = q0 + m0;
-                    const int q_m1 = q0 + m1;
-                    if (full_q_tile) {
-                        qscale_m0 = __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk]);
-                        qscale_m1 = __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk]);
-                    } else {
-                        qscale_m0 = (q_m0 < Q)
-                            ? __ldg(&A_chunk_scales[(size_t)q_m0 * (size_t)A_scale_stride + (size_t)chunk])
-                            : 0.0f;
-                        qscale_m1 = (q_m1 < Q)
-                            ? __ldg(&A_chunk_scales[(size_t)q_m1 * (size_t)A_scale_stride + (size_t)chunk])
-                            : 0.0f;
-                    }
-                }
-                qscale_m0 = __shfl_sync(0xffffffff, qscale_m0, lane & ~3);
-                qscale_m1 = __shfl_sync(0xffffffff, qscale_m1, lane & ~3);
             }
+            qscale_m0 = __shfl_sync(0xffffffff, qscale_m0, lane & ~3);
+            qscale_m1 = __shfl_sync(0xffffffff, qscale_m1, lane & ~3);
         }
 
         if (cache_sb) {
@@ -2145,7 +2102,6 @@ void popcount_weighted_keys_literal_fused_bmma_tc_kernel_tm32(
     (void)R_total;
     (void)out_global;
     (void)use_cpasync;
-    (void)use_qscale_shared;
 #endif
 }
 
@@ -2299,17 +2255,6 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                 cached_use_cpasync = use_cpasync_env;
             }
             int use_cpasync = cached_use_cpasync;
-            // Optional shared qscale tile for chunk-scale mode. Reduces duplicated
-            // global qscale loads across warps in BMMA kernels.
-            static int cached_use_qscale_shared = -1;
-            if (cached_use_qscale_shared < 0) {
-                int v = 1;
-                if (const char* s = getenv("BSI_TC_QS_SHARED")) {
-                    v = (atoi(s) != 0) ? 1 : 0;
-                }
-                cached_use_qscale_shared = v;
-            }
-            const int use_qscale_shared = cached_use_qscale_shared;
 
             // Optional TM selection for BMMA TC path:
             // - auto (default): try TM32 then TM16 fallback
@@ -2341,8 +2286,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                     (size_t)stages * (size_t)Sa * (size_t)TM_TOTAL * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                     (size_t)stages * (size_t)Sb * (size_t)TN * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                     (size_t)TM_TOTAL * (size_t)Sa * sizeof(float) +
-                    (size_t)TN * (size_t)Sb * sizeof(float) +
-                    (size_t)TM_TOTAL * sizeof(float);
+                    (size_t)TN * (size_t)Sb * sizeof(float);
 
                 // If the pipelined (double-buffered) version doesn't fit, retry with stages=1.
                 if (shared_bytes > (size_t)max_shared && use_cpasync) {
@@ -2352,8 +2296,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                         (size_t)Sa * (size_t)TM_TOTAL * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                         (size_t)Sb * (size_t)TN * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                         (size_t)TM_TOTAL * (size_t)Sa * sizeof(float) +
-                        (size_t)TN * (size_t)Sb * sizeof(float) +
-                        (size_t)TM_TOTAL * sizeof(float);
+                        (size_t)TN * (size_t)Sb * sizeof(float);
                 }
 
                 if (shared_bytes <= (size_t)max_shared) {
@@ -2382,8 +2325,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                         scale_inv,
                         R_total,
                         out_global,
-                        use_cpasync,
-                        use_qscale_shared);
+                        use_cpasync);
                     return true;
                 }
                 return false;
@@ -2400,8 +2342,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                     (size_t)Sa * (size_t)TM * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                     (size_t)Sb * (size_t)TN * (size_t)K_STRIDE32 * sizeof(uint32_t) +
                     (size_t)TM * (size_t)Sa * sizeof(float) +
-                    (size_t)TN * (size_t)Sb * sizeof(float) +
-                    (size_t)TM * sizeof(float);
+                    (size_t)TN * (size_t)Sb * sizeof(float);
 
                 if (shared_bytes <= (size_t)max_shared) {
                     static size_t configured_shared_tm16 = 0;
@@ -2428,8 +2369,7 @@ extern "C" void launch_popcount_weighted_keys_literal_fused_multiq(
                         indices_q,
                         scale_inv,
                         R_total,
-                        out_global,
-                        use_qscale_shared);
+                        out_global);
                     return true;
                 }
                 return false;

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_quant.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_quant.cuh
@@ -1,0 +1,351 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <stdint.h>
+#include <math.h>
+
+template <typename T>
+__device__ __forceinline__ float bsi_cast_to_float(T v) {
+    return static_cast<float>(v);
+}
+
+template <>
+__device__ __forceinline__ float bsi_cast_to_float<half>(half v) {
+    return __half2float(v);
+}
+
+template <>
+__device__ __forceinline__ float bsi_cast_to_float<__nv_bfloat16>(__nv_bfloat16 v) {
+    return __bfloat162float(v);
+}
+
+__device__ __forceinline__ long long bsi_round_half_away_to_ll(double x) {
+    if (x >= 0.0) {
+        return static_cast<long long>(floor(x + 0.5));
+    }
+    return -static_cast<long long>(floor(-x + 0.5));
+}
+
+__device__ __forceinline__ unsigned long long bsi_uabs_ll(long long v) {
+    return static_cast<unsigned long long>(v >= 0 ? v : -v);
+}
+
+__device__ __forceinline__ unsigned long long bsi_warp_reduce_max_u64(unsigned long long v) {
+    for (int off = 16; off > 0; off >>= 1) {
+        unsigned long long o = __shfl_down_sync(0xffffffff, v, off);
+        if (o > v) v = o;
+    }
+    return v;
+}
+
+__device__ __forceinline__ double bsi_warp_reduce_sum_f64(double v) {
+    for (int off = 16; off > 0; off >>= 1) {
+        v += __shfl_down_sync(0xffffffff, v, off);
+    }
+    return v;
+}
+
+template <int BLOCK_SIZE>
+__device__ __forceinline__ void bsi_block_reduce_max_sum(
+    unsigned long long local_max,
+    double local_sum,
+    unsigned long long* out_max,
+    double* out_sum) {
+    constexpr int WARPS = BLOCK_SIZE / 32;
+    __shared__ unsigned long long smax[WARPS];
+    __shared__ double ssum[WARPS];
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+    local_max = bsi_warp_reduce_max_u64(local_max);
+    local_sum = bsi_warp_reduce_sum_f64(local_sum);
+    if (lane == 0) {
+        smax[warp] = local_max;
+        ssum[warp] = local_sum;
+    }
+    __syncthreads();
+
+    if (warp == 0) {
+        unsigned long long v_max = (lane < WARPS) ? smax[lane] : 0ULL;
+        double v_sum = (lane < WARPS) ? ssum[lane] : 0.0;
+        v_max = bsi_warp_reduce_max_u64(v_max);
+        v_sum = bsi_warp_reduce_sum_f64(v_sum);
+        if (lane == 0) {
+            *out_max = v_max;
+            *out_sum = v_sum;
+        }
+    }
+}
+
+__device__ __forceinline__ int bsi_compute_shift(
+    unsigned long long max_abs,
+    double sum_abs,
+    int count,
+    int fixed_bits,
+    float clip_k) {
+    if (fixed_bits <= 0) return 0;
+    int bits = 0;
+    if (clip_k > 0.0f && count > 0) {
+        double effective = static_cast<double>(max_abs);
+        const double mean_abs = sum_abs / static_cast<double>(count);
+        const double clip_max = mean_abs * static_cast<double>(clip_k);
+        if (clip_max < effective) effective = clip_max;
+        if (effective > 0.0) {
+            int exp2 = 0;
+            (void)frexp(effective, &exp2);
+            bits = exp2;
+        }
+    } else {
+        bits = (max_abs > 0ULL) ? (64 - __clzll(max_abs)) : 0;
+    }
+
+    int shift = bits - (fixed_bits - 1);
+    if (shift < 0) shift = 0;
+    if (shift > 62) shift = 62;
+    return shift;
+}
+
+template <typename T>
+__global__ void quantize_round_to_int64_batch_kernel(
+    const T* __restrict__ input,
+    int64_t total,
+    double dec_scale,
+    long long* __restrict__ out_ints) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+    if (idx >= total) return;
+    const float f = bsi_cast_to_float(input[idx]);
+    const double scaled = static_cast<double>(f) * dec_scale;
+    out_ints[idx] = bsi_round_half_away_to_ll(scaled);
+}
+
+template <int BLOCK_SIZE>
+__global__ void compute_row_shift_scale_kernel(
+    const long long* __restrict__ ints,
+    int64_t Q,
+    int64_t d,
+    int fixed_bits,
+    float clip_k,
+    int* __restrict__ shifts,
+    float* __restrict__ scales) {
+    const int64_t row = static_cast<int64_t>(blockIdx.x);
+    if (row >= Q) return;
+
+    unsigned long long local_max = 0ULL;
+    double local_sum = 0.0;
+    const int64_t base = row * d;
+    for (int64_t c = threadIdx.x; c < d; c += BLOCK_SIZE) {
+        const unsigned long long av = bsi_uabs_ll(ints[base + c]);
+        if (av > local_max) local_max = av;
+        local_sum += static_cast<double>(av);
+    }
+
+    __shared__ unsigned long long block_max;
+    __shared__ double block_sum;
+    bsi_block_reduce_max_sum<BLOCK_SIZE>(local_max, local_sum, &block_max, &block_sum);
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        const int shift = bsi_compute_shift(block_max, block_sum, static_cast<int>(d), fixed_bits, clip_k);
+        shifts[row] = shift;
+        scales[row] = static_cast<float>(static_cast<unsigned long long>(1ULL) << shift);
+    }
+}
+
+template <int BLOCK_SIZE>
+__global__ void compute_chunk_shift_scale_kernel(
+    const long long* __restrict__ ints,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    int fixed_bits,
+    float clip_k,
+    int* __restrict__ shifts,
+    float* __restrict__ scales) {
+    const int chunk = blockIdx.x;
+    const int64_t row = static_cast<int64_t>(blockIdx.y);
+    if (row >= Q || chunk >= chunks) return;
+
+    const int64_t start = static_cast<int64_t>(chunk) * 256LL;
+    int64_t rem = d - start;
+    if (rem < 0) rem = 0;
+    const int64_t valid = (rem < 256LL) ? rem : 256LL;
+    if (valid <= 0) {
+        if (threadIdx.x == 0) {
+            const int idx = static_cast<int>(row) * chunks + chunk;
+            shifts[idx] = 0;
+            scales[idx] = 1.0f;
+        }
+        return;
+    }
+
+    unsigned long long local_max = 0ULL;
+    double local_sum = 0.0;
+    const int64_t base = row * d + start;
+    for (int64_t i = threadIdx.x; i < valid; i += BLOCK_SIZE) {
+        const unsigned long long av = bsi_uabs_ll(ints[base + i]);
+        if (av > local_max) local_max = av;
+        local_sum += static_cast<double>(av);
+    }
+
+    __shared__ unsigned long long block_max;
+    __shared__ double block_sum;
+    bsi_block_reduce_max_sum<BLOCK_SIZE>(local_max, local_sum, &block_max, &block_sum);
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        const int shift = bsi_compute_shift(block_max, block_sum, static_cast<int>(valid), fixed_bits, clip_k);
+        const int idx = static_cast<int>(row) * chunks + chunk;
+        shifts[idx] = shift;
+        scales[idx] = static_cast<float>(static_cast<unsigned long long>(1ULL) << shift);
+    }
+}
+
+__global__ void apply_row_shift_clamp_kernel(
+    long long* __restrict__ ints,
+    int64_t total,
+    int64_t d,
+    const int* __restrict__ shifts,
+    long long qmin,
+    long long qmax) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+    if (idx >= total) return;
+
+    const int64_t row = idx / d;
+    const int shift = shifts[row];
+    const long long v = ints[idx];
+    const unsigned long long av = bsi_uabs_ll(v);
+    const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+    const unsigned long long q = (av + round_add) >> shift;
+
+    long long out = (v < 0) ? -static_cast<long long>(q) : static_cast<long long>(q);
+    if (out < qmin) out = qmin;
+    if (out > qmax) out = qmax;
+    ints[idx] = out;
+}
+
+__global__ void apply_chunk_shift_clamp_kernel(
+    long long* __restrict__ ints,
+    int64_t total,
+    int64_t d,
+    int chunks,
+    const int* __restrict__ shifts,
+    long long qmin,
+    long long qmax) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+    if (idx >= total) return;
+
+    const int64_t row = idx / d;
+    const int64_t col = idx - row * d;
+    int chunk = static_cast<int>(col >> 8); // /256
+    if (chunk >= chunks) chunk = chunks - 1;
+    const int shift = shifts[static_cast<int>(row) * chunks + chunk];
+
+    const long long v = ints[idx];
+    const unsigned long long av = bsi_uabs_ll(v);
+    const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+    const unsigned long long q = (av + round_add) >> shift;
+    long long out = (v < 0) ? -static_cast<long long>(q) : static_cast<long long>(q);
+    if (out < qmin) out = qmin;
+    if (out > qmax) out = qmax;
+    ints[idx] = out;
+}
+
+extern "C" void launch_quantize_round_to_int64_batch(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    double dec_scale,
+    long long* out_ints,
+    cudaStream_t stream) {
+    const int64_t total = Q * d;
+    if (total <= 0) return;
+    constexpr int BLOCK = 256;
+    const int grid = static_cast<int>((total + BLOCK - 1) / BLOCK);
+    switch (input_dtype) {
+        case 0:
+            quantize_round_to_int64_batch_kernel<float><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), total, dec_scale, out_ints);
+            break;
+        case 1:
+            quantize_round_to_int64_batch_kernel<half><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const half*>(input), total, dec_scale, out_ints);
+            break;
+        case 2:
+            quantize_round_to_int64_batch_kernel<__nv_bfloat16><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), total, dec_scale, out_ints);
+            break;
+        default:
+            quantize_round_to_int64_batch_kernel<float><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), total, dec_scale, out_ints);
+            break;
+    }
+}
+
+extern "C" void launch_compute_row_shift_scale(
+    const long long* ints,
+    int64_t Q,
+    int64_t d,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0) return;
+    constexpr int BLOCK = 256;
+    compute_row_shift_scale_kernel<BLOCK><<<static_cast<int>(Q), BLOCK, 0, stream>>>(
+        ints, Q, d, fixed_bits, clip_k, shifts, scales);
+}
+
+extern "C" void launch_compute_chunk_shift_scale(
+    const long long* ints,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0 || chunks <= 0) return;
+    constexpr int BLOCK = 256;
+    dim3 grid(static_cast<unsigned>(chunks), static_cast<unsigned>(Q), 1);
+    compute_chunk_shift_scale_kernel<BLOCK><<<grid, BLOCK, 0, stream>>>(
+        ints, Q, d, chunks, fixed_bits, clip_k, shifts, scales);
+}
+
+extern "C" void launch_apply_row_shift_clamp(
+    long long* ints,
+    int64_t Q,
+    int64_t d,
+    const int* shifts,
+    int fixed_bits,
+    cudaStream_t stream) {
+    const int64_t total = Q * d;
+    if (total <= 0) return;
+    const long long qmax = (static_cast<long long>(1) << (fixed_bits - 1)) - 1LL;
+    const long long qmin = -(static_cast<long long>(1) << (fixed_bits - 1));
+    constexpr int BLOCK = 256;
+    const int grid = static_cast<int>((total + BLOCK - 1) / BLOCK);
+    apply_row_shift_clamp_kernel<<<grid, BLOCK, 0, stream>>>(ints, total, d, shifts, qmin, qmax);
+}
+
+extern "C" void launch_apply_chunk_shift_clamp(
+    long long* ints,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    const int* shifts,
+    int fixed_bits,
+    cudaStream_t stream) {
+    const int64_t total = Q * d;
+    if (total <= 0) return;
+    const long long qmax = (static_cast<long long>(1) << (fixed_bits - 1)) - 1LL;
+    const long long qmin = -(static_cast<long long>(1) << (fixed_bits - 1));
+    constexpr int BLOCK = 256;
+    const int grid = static_cast<int>((total + BLOCK - 1) / BLOCK);
+    apply_chunk_shift_clamp_kernel<<<grid, BLOCK, 0, stream>>>(
+        ints, total, d, chunks, shifts, qmin, qmax);
+}

--- a/bsi_ops/csrc/cuda/bsi_cuda_kernels_quant.cuh
+++ b/bsi_ops/csrc/cuda/bsi_cuda_kernels_quant.cuh
@@ -252,6 +252,389 @@ __global__ void apply_chunk_shift_clamp_kernel(
     ints[idx] = out;
 }
 
+template <typename T, int BLOCK_SIZE>
+__global__ void compute_row_shift_scale_from_input_kernel(
+    const T* __restrict__ input,
+    int64_t Q,
+    int64_t d,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* __restrict__ shifts,
+    float* __restrict__ scales) {
+    const int64_t row = static_cast<int64_t>(blockIdx.x);
+    if (row >= Q) return;
+
+    unsigned long long local_max = 0ULL;
+    double local_sum = 0.0;
+    const int64_t base = row * d;
+    for (int64_t c = threadIdx.x; c < d; c += BLOCK_SIZE) {
+        const float f = bsi_cast_to_float(input[base + c]);
+        const long long v = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(v);
+        if (av > local_max) local_max = av;
+        local_sum += static_cast<double>(av);
+    }
+
+    __shared__ unsigned long long block_max;
+    __shared__ double block_sum;
+    bsi_block_reduce_max_sum<BLOCK_SIZE>(local_max, local_sum, &block_max, &block_sum);
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        const int shift = bsi_compute_shift(block_max, block_sum, static_cast<int>(d), fixed_bits, clip_k);
+        shifts[row] = shift;
+        scales[row] = static_cast<float>(static_cast<unsigned long long>(1ULL) << shift);
+    }
+}
+
+template <typename T, int BLOCK_SIZE>
+__global__ void compute_chunk_shift_scale_from_input_kernel(
+    const T* __restrict__ input,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* __restrict__ shifts,
+    float* __restrict__ scales) {
+    const int chunk = blockIdx.x;
+    const int64_t row = static_cast<int64_t>(blockIdx.y);
+    if (row >= Q || chunk >= chunks) return;
+
+    const int64_t start = static_cast<int64_t>(chunk) * 256LL;
+    int64_t rem = d - start;
+    if (rem < 0) rem = 0;
+    const int64_t valid = (rem < 256LL) ? rem : 256LL;
+    if (valid <= 0) {
+        if (threadIdx.x == 0) {
+            const int idx = static_cast<int>(row) * chunks + chunk;
+            shifts[idx] = 0;
+            scales[idx] = 1.0f;
+        }
+        return;
+    }
+
+    unsigned long long local_max = 0ULL;
+    double local_sum = 0.0;
+    const int64_t base = row * d + start;
+    for (int64_t i = threadIdx.x; i < valid; i += BLOCK_SIZE) {
+        const float f = bsi_cast_to_float(input[base + i]);
+        const long long v = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(v);
+        if (av > local_max) local_max = av;
+        local_sum += static_cast<double>(av);
+    }
+
+    __shared__ unsigned long long block_max;
+    __shared__ double block_sum;
+    bsi_block_reduce_max_sum<BLOCK_SIZE>(local_max, local_sum, &block_max, &block_sum);
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        const int shift = bsi_compute_shift(block_max, block_sum, static_cast<int>(valid), fixed_bits, clip_k);
+        const int idx = static_cast<int>(row) * chunks + chunk;
+        shifts[idx] = shift;
+        scales[idx] = static_cast<float>(static_cast<unsigned long long>(1ULL) << shift);
+    }
+}
+
+template <typename T>
+__global__ void quantize_shift_pack_row_batch_oneshot_kernel(
+    const T* __restrict__ input,
+    int64_t Q,
+    int64_t d,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* __restrict__ shifts,
+    unsigned long long* __restrict__ out) {
+    const int q = blockIdx.z;
+    if (q >= Q) return;
+
+    const int warps_per_block = blockDim.x >> 5;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int words_group = blockIdx.x;
+    const int word_idx = words_group * warps_per_block + warp;
+    if (word_idx >= words_per_slice) return;
+
+    const T* in_q = input + static_cast<int64_t>(q) * d;
+    unsigned long long* out_q =
+        out + (static_cast<size_t>(q) * static_cast<size_t>(slices) * static_cast<size_t>(words_per_slice));
+
+    const int shift = shifts[q];
+    const long long qmax = (static_cast<long long>(1) << (fixed_bits - 1)) - 1LL;
+    const long long qmin = -(static_cast<long long>(1) << (fixed_bits - 1));
+
+    const int64_t row0 = static_cast<int64_t>(word_idx) * 64LL + static_cast<int64_t>(lane);
+    const int64_t row1 = row0 + 32LL;
+
+    unsigned long long v0 = 0ULL;
+    unsigned long long v1 = 0ULL;
+    if (row0 < d) {
+        const float f = bsi_cast_to_float(in_q[row0]);
+        const long long r = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(r);
+        const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+        const unsigned long long uq = (av + round_add) >> shift;
+        long long qv = (r < 0) ? -static_cast<long long>(uq) : static_cast<long long>(uq);
+        if (qv < qmin) qv = qmin;
+        if (qv > qmax) qv = qmax;
+        v0 = static_cast<unsigned long long>(qv) & value_mask;
+    }
+    if (row1 < d) {
+        const float f = bsi_cast_to_float(in_q[row1]);
+        const long long r = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(r);
+        const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+        const unsigned long long uq = (av + round_add) >> shift;
+        long long qv = (r < 0) ? -static_cast<long long>(uq) : static_cast<long long>(uq);
+        if (qv < qmin) qv = qmin;
+        if (qv > qmax) qv = qmax;
+        v1 = static_cast<unsigned long long>(qv) & value_mask;
+    }
+
+    for (int slice = 0; slice < slices; ++slice) {
+        const bool b0 = ((v0 >> slice) & 1ULL) != 0ULL;
+        const bool b1 = ((v1 >> slice) & 1ULL) != 0ULL;
+        const unsigned lo = __ballot_sync(0xffffffff, b0);
+        const unsigned hi = __ballot_sync(0xffffffff, b1);
+        if (lane == 0) {
+            out_q[static_cast<size_t>(slice) * static_cast<size_t>(words_per_slice) +
+                  static_cast<size_t>(word_idx)] =
+                static_cast<unsigned long long>(lo) | (static_cast<unsigned long long>(hi) << 32);
+        }
+    }
+}
+
+template <typename T>
+__global__ void quantize_shift_pack_chunk_batch_oneshot_kernel(
+    const T* __restrict__ input,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* __restrict__ shifts,
+    unsigned long long* __restrict__ out) {
+    const int q = blockIdx.z;
+    if (q >= Q) return;
+
+    const int warps_per_block = blockDim.x >> 5;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int words_group = blockIdx.x;
+    const int word_idx = words_group * warps_per_block + warp;
+    if (word_idx >= words_per_slice) return;
+
+    const T* in_q = input + static_cast<int64_t>(q) * d;
+    unsigned long long* out_q =
+        out + (static_cast<size_t>(q) * static_cast<size_t>(slices) * static_cast<size_t>(words_per_slice));
+
+    const long long qmax = (static_cast<long long>(1) << (fixed_bits - 1)) - 1LL;
+    const long long qmin = -(static_cast<long long>(1) << (fixed_bits - 1));
+    const int shift_base = q * chunks;
+
+    const int64_t row0 = static_cast<int64_t>(word_idx) * 64LL + static_cast<int64_t>(lane);
+    const int64_t row1 = row0 + 32LL;
+
+    unsigned long long v0 = 0ULL;
+    unsigned long long v1 = 0ULL;
+    if (row0 < d) {
+        const int chunk0 = static_cast<int>(row0 >> 8);
+        const int shift = shifts[shift_base + chunk0];
+        const float f = bsi_cast_to_float(in_q[row0]);
+        const long long r = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(r);
+        const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+        const unsigned long long uq = (av + round_add) >> shift;
+        long long qv = (r < 0) ? -static_cast<long long>(uq) : static_cast<long long>(uq);
+        if (qv < qmin) qv = qmin;
+        if (qv > qmax) qv = qmax;
+        v0 = static_cast<unsigned long long>(qv) & value_mask;
+    }
+    if (row1 < d) {
+        const int chunk1 = static_cast<int>(row1 >> 8);
+        const int shift = shifts[shift_base + chunk1];
+        const float f = bsi_cast_to_float(in_q[row1]);
+        const long long r = bsi_round_half_away_to_ll(static_cast<double>(f) * dec_scale);
+        const unsigned long long av = bsi_uabs_ll(r);
+        const unsigned long long round_add = (shift > 0) ? (1ULL << (shift - 1)) : 0ULL;
+        const unsigned long long uq = (av + round_add) >> shift;
+        long long qv = (r < 0) ? -static_cast<long long>(uq) : static_cast<long long>(uq);
+        if (qv < qmin) qv = qmin;
+        if (qv > qmax) qv = qmax;
+        v1 = static_cast<unsigned long long>(qv) & value_mask;
+    }
+
+    for (int slice = 0; slice < slices; ++slice) {
+        const bool b0 = ((v0 >> slice) & 1ULL) != 0ULL;
+        const bool b1 = ((v1 >> slice) & 1ULL) != 0ULL;
+        const unsigned lo = __ballot_sync(0xffffffff, b0);
+        const unsigned hi = __ballot_sync(0xffffffff, b1);
+        if (lane == 0) {
+            out_q[static_cast<size_t>(slice) * static_cast<size_t>(words_per_slice) +
+                  static_cast<size_t>(word_idx)] =
+                static_cast<unsigned long long>(lo) | (static_cast<unsigned long long>(hi) << 32);
+        }
+    }
+}
+
+extern "C" void launch_compute_row_shift_scale_from_input(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0) return;
+    constexpr int BLOCK = 256;
+    const int grid = static_cast<int>(Q);
+    switch (input_dtype) {
+        case 0:
+            compute_row_shift_scale_from_input_kernel<float, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        case 1:
+            compute_row_shift_scale_from_input_kernel<half, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const half*>(input), Q, d, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        case 2:
+            compute_row_shift_scale_from_input_kernel<__nv_bfloat16, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), Q, d, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        default:
+            compute_row_shift_scale_from_input_kernel<float, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+    }
+}
+
+extern "C" void launch_compute_chunk_shift_scale_from_input(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0 || chunks <= 0) return;
+    constexpr int BLOCK = 256;
+    dim3 grid(static_cast<unsigned>(chunks), static_cast<unsigned>(Q), 1);
+    switch (input_dtype) {
+        case 0:
+            compute_chunk_shift_scale_from_input_kernel<float, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, chunks, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        case 1:
+            compute_chunk_shift_scale_from_input_kernel<half, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const half*>(input), Q, d, chunks, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        case 2:
+            compute_chunk_shift_scale_from_input_kernel<__nv_bfloat16, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), Q, d, chunks, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+        default:
+            compute_chunk_shift_scale_from_input_kernel<float, BLOCK><<<grid, BLOCK, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, chunks, dec_scale, fixed_bits, clip_k, shifts, scales);
+            break;
+    }
+}
+
+extern "C" void launch_quantize_shift_pack_row_batch(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* shifts,
+    unsigned long long* out,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0 || slices <= 0 || words_per_slice <= 0) return;
+    const int warps_per_block = 8;
+    dim3 block(warps_per_block * 32);
+    dim3 grid((words_per_slice + warps_per_block - 1) / warps_per_block, 1, static_cast<unsigned>(Q));
+    switch (input_dtype) {
+        case 0:
+            quantize_shift_pack_row_batch_oneshot_kernel<float><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        case 1:
+            quantize_shift_pack_row_batch_oneshot_kernel<half><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const half*>(input), Q, d, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        case 2:
+            quantize_shift_pack_row_batch_oneshot_kernel<__nv_bfloat16><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), Q, d, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        default:
+            quantize_shift_pack_row_batch_oneshot_kernel<float><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const float*>(input), Q, d, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+    }
+}
+
+extern "C" void launch_quantize_shift_pack_chunk_batch(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* shifts,
+    unsigned long long* out,
+    cudaStream_t stream) {
+    if (Q <= 0 || d <= 0 || chunks <= 0 || slices <= 0 || words_per_slice <= 0) return;
+    const int warps_per_block = 8;
+    dim3 block(warps_per_block * 32);
+    dim3 grid((words_per_slice + warps_per_block - 1) / warps_per_block, 1, static_cast<unsigned>(Q));
+    switch (input_dtype) {
+        case 0:
+            quantize_shift_pack_chunk_batch_oneshot_kernel<float><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const float*>(input),
+                Q, d, chunks, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        case 1:
+            quantize_shift_pack_chunk_batch_oneshot_kernel<half><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const half*>(input),
+                Q, d, chunks, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        case 2:
+            quantize_shift_pack_chunk_batch_oneshot_kernel<__nv_bfloat16><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input),
+                Q, d, chunks, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+        default:
+            quantize_shift_pack_chunk_batch_oneshot_kernel<float><<<grid, block, 0, stream>>>(
+                reinterpret_cast<const float*>(input),
+                Q, d, chunks, slices, words_per_slice, value_mask, dec_scale, fixed_bits, shifts, out);
+            break;
+    }
+}
+
 extern "C" void launch_quantize_round_to_int64_batch(
     const void* input,
     int input_dtype,

--- a/bsi_ops/csrc/cuda/bsi_vector_cuda.cpp
+++ b/bsi_ops/csrc/cuda/bsi_vector_cuda.cpp
@@ -154,6 +154,60 @@ extern "C" void launch_apply_chunk_shift_clamp(
     int fixed_bits,
     cudaStream_t stream);
 
+extern "C" void launch_compute_row_shift_scale_from_input(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream);
+
+extern "C" void launch_compute_chunk_shift_scale_from_input(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    double dec_scale,
+    int fixed_bits,
+    float clip_k,
+    int* shifts,
+    float* scales,
+    cudaStream_t stream);
+
+extern "C" void launch_quantize_shift_pack_row_batch(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* shifts,
+    unsigned long long* out,
+    cudaStream_t stream);
+
+extern "C" void launch_quantize_shift_pack_chunk_batch(
+    const void* input,
+    int input_dtype,
+    int64_t Q,
+    int64_t d,
+    int chunks,
+    int slices,
+    int words_per_slice,
+    unsigned long long value_mask,
+    double dec_scale,
+    int fixed_bits,
+    const int* shifts,
+    unsigned long long* out,
+    cudaStream_t stream);
+
 extern "C" void launch_slice_popcount_sum(
     const unsigned long long* words,
     int S,
@@ -285,6 +339,24 @@ static bool bsi_cuda_custom_quant_enabled() {
     return cached != 0;
 }
 
+static bool bsi_cuda_fused_qpack_enabled() {
+    static int cached = -1;
+    if (cached >= 0) return cached != 0;
+    int v = 1; // default on
+    if (const char* s = std::getenv("BSI_FUSED_QPACK")) {
+        v = (std::atoi(s) != 0) ? 1 : 0;
+    }
+    cached = v;
+    return cached != 0;
+}
+
+static int bsi_cuda_input_dtype_code(const torch::Tensor& values) {
+    int input_dtype = 0;
+    if (values.scalar_type() == torch::kFloat16) input_dtype = 1;
+    else if (values.scalar_type() == torch::kBFloat16) input_dtype = 2;
+    return input_dtype;
+}
+
 static uint64_t g_last_query_build_quantize_ns = 0;
 static uint64_t g_last_query_build_pack_ns = 0;
 static uint64_t g_last_query_build_total_ns = 0;
@@ -324,6 +396,164 @@ static inline torch::Tensor round_shift_right_signed(const torch::Tensor& ints, 
         torch::zeros_like(shift));
     auto abs_rounded = torch::bitwise_right_shift(abs_ints + round_add, shift);
     return torch::where(ints.lt(0), -abs_rounded, abs_rounded);
+}
+
+static bool bsi_cuda_build_fixed_query_words_fused(const torch::Tensor& input,
+                                                   int decimal_places,
+                                                   int fixed_bits,
+                                                   bool chunk_scale,
+                                                   const torch::Device& device,
+                                                   bool profile_cuda,
+                                                   torch::Tensor& words_out,
+                                                   torch::Tensor& scale_out,
+                                                   float& quantize_ms,
+                                                   float& pack_ms) {
+    if (fixed_bits <= 0 || !input.is_cuda()) {
+        return false;
+    }
+    auto values = input.to(device, input.scalar_type(), /*non_blocking=*/true).contiguous();
+    if (!(values.scalar_type() == torch::kFloat32 ||
+          values.scalar_type() == torch::kFloat16 ||
+          values.scalar_type() == torch::kBFloat16)) {
+        values = values.to(torch::kFloat32);
+    }
+    TORCH_CHECK(values.dim() == 2, "Fused fixed-bit query build expects 2D input");
+    const int64_t Q = values.size(0);
+    const int64_t d = values.size(1);
+    const int slices = std::max(1, fixed_bits);
+    const int words_per_slice = (d > 0) ? static_cast<int>((d + 63) / 64) : 1;
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    words_out = torch::zeros({Q, slices, words_per_slice},
+                             torch::TensorOptions().dtype(torch::kInt64).device(device));
+
+    if (Q <= 0 || d <= 0) {
+        if (chunk_scale) {
+            const int chunks = static_cast<int>((d + 255) / 256);
+            scale_out = torch::ones({Q, chunks}, torch::TensorOptions().dtype(torch::kFloat32).device(device));
+        } else {
+            scale_out = torch::ones({Q}, torch::TensorOptions().dtype(torch::kFloat32).device(device));
+        }
+        quantize_ms = 0.0f;
+        pack_ms = 0.0f;
+        return true;
+    }
+
+    const int input_dtype = bsi_cuda_input_dtype_code(values);
+    const double dec_scale = std::pow(10.0, static_cast<double>(decimal_places));
+    const float clip_k = bsi_cuda_fixed_clip_k();
+    const unsigned long long value_mask =
+        (slices >= 64) ? ~0ULL : ((1ULL << slices) - 1ULL);
+
+    cudaEvent_t quantize_start_evt = nullptr;
+    cudaEvent_t quantize_end_evt = nullptr;
+    cudaEvent_t pack_start_evt = nullptr;
+    cudaEvent_t pack_end_evt = nullptr;
+    if (profile_cuda) {
+        cudaEventCreate(&quantize_start_evt);
+        cudaEventCreate(&quantize_end_evt);
+        cudaEventCreate(&pack_start_evt);
+        cudaEventCreate(&pack_end_evt);
+    }
+
+    if (chunk_scale) {
+        const int chunks = static_cast<int>((d + 255) / 256);
+        auto shifts = torch::empty({Q, chunks}, torch::TensorOptions().dtype(torch::kInt32).device(device));
+        auto scales = torch::empty({Q, chunks}, torch::TensorOptions().dtype(torch::kFloat32).device(device));
+
+        if (profile_cuda) cudaEventRecord(quantize_start_evt, stream.stream());
+        launch_compute_chunk_shift_scale_from_input(
+            values.data_ptr(),
+            input_dtype,
+            Q,
+            d,
+            chunks,
+            dec_scale,
+            fixed_bits,
+            clip_k,
+            shifts.data_ptr<int>(),
+            tensor_data_ptr<float>(scales),
+            stream.stream());
+        if (profile_cuda) {
+            cudaEventRecord(quantize_end_evt, stream.stream());
+            cudaEventSynchronize(quantize_end_evt);
+            cudaEventElapsedTime(&quantize_ms, quantize_start_evt, quantize_end_evt);
+        }
+
+        if (profile_cuda) cudaEventRecord(pack_start_evt, stream.stream());
+        launch_quantize_shift_pack_chunk_batch(
+            values.data_ptr(),
+            input_dtype,
+            Q,
+            d,
+            chunks,
+            slices,
+            words_per_slice,
+            value_mask,
+            dec_scale,
+            fixed_bits,
+            shifts.data_ptr<int>(),
+            reinterpret_cast<unsigned long long*>(tensor_data_ptr<int64_t>(words_out)),
+            stream.stream());
+        if (profile_cuda) {
+            cudaEventRecord(pack_end_evt, stream.stream());
+            cudaEventSynchronize(pack_end_evt);
+            cudaEventElapsedTime(&pack_ms, pack_start_evt, pack_end_evt);
+        }
+
+        scale_out = scales.contiguous();
+    } else {
+        auto shifts = torch::empty({Q}, torch::TensorOptions().dtype(torch::kInt32).device(device));
+        auto scales = torch::empty({Q}, torch::TensorOptions().dtype(torch::kFloat32).device(device));
+
+        if (profile_cuda) cudaEventRecord(quantize_start_evt, stream.stream());
+        launch_compute_row_shift_scale_from_input(
+            values.data_ptr(),
+            input_dtype,
+            Q,
+            d,
+            dec_scale,
+            fixed_bits,
+            clip_k,
+            shifts.data_ptr<int>(),
+            tensor_data_ptr<float>(scales),
+            stream.stream());
+        if (profile_cuda) {
+            cudaEventRecord(quantize_end_evt, stream.stream());
+            cudaEventSynchronize(quantize_end_evt);
+            cudaEventElapsedTime(&quantize_ms, quantize_start_evt, quantize_end_evt);
+        }
+
+        if (profile_cuda) cudaEventRecord(pack_start_evt, stream.stream());
+        launch_quantize_shift_pack_row_batch(
+            values.data_ptr(),
+            input_dtype,
+            Q,
+            d,
+            slices,
+            words_per_slice,
+            value_mask,
+            dec_scale,
+            fixed_bits,
+            shifts.data_ptr<int>(),
+            reinterpret_cast<unsigned long long*>(tensor_data_ptr<int64_t>(words_out)),
+            stream.stream());
+        if (profile_cuda) {
+            cudaEventRecord(pack_end_evt, stream.stream());
+            cudaEventSynchronize(pack_end_evt);
+            cudaEventElapsedTime(&pack_ms, pack_start_evt, pack_end_evt);
+        }
+
+        scale_out = scales.contiguous();
+    }
+
+    if (profile_cuda) {
+        cudaEventDestroy(quantize_start_evt);
+        cudaEventDestroy(quantize_end_evt);
+        cudaEventDestroy(pack_start_evt);
+        cudaEventDestroy(pack_end_evt);
+    }
+    return true;
 }
 
 static QuantizedIntsAndScale bsi_cuda_quantize_to_int64_and_scale(const torch::Tensor& input,
@@ -766,6 +996,73 @@ BsiQueryBatchCudaData build_bsi_queries_cuda_batch_data(const torch::Tensor& inp
     const bool profile_cuda = profile && input.is_cuda();
     float quantize_ms = 0.0f;
     float pack_ms = 0.0f;
+    const int64_t Q_input = input.size(0);
+    const int64_t d_input = input.size(1);
+
+    // Fused fixed-bit query builder: compute shifts/scales directly from input and
+    // quantize+pack directly into bitplanes (no intermediate int64 staging tensor).
+    if (!for_keys &&
+        fixed_bits > 0 &&
+        input.is_cuda() &&
+        bsi_cuda_custom_quant_enabled() &&
+        bsi_cuda_fused_qpack_enabled()) {
+        const int offset = 0;
+        const int slices = std::max(1, fixed_bits);
+        const int words_per_slice = (d_input > 0) ? static_cast<int>((d_input + 63) / 64) : 1;
+
+        torch::Tensor words;
+        torch::Tensor scale;
+        const bool fused_ok = bsi_cuda_build_fixed_query_words_fused(
+            input,
+            decimal_places,
+            fixed_bits,
+            chunk_scale,
+            device,
+            profile_cuda,
+            words,
+            scale,
+            quantize_ms,
+            pack_ms);
+
+        if (fused_ok) {
+            auto weights_twos = make_slice_weights_cuda_cached(slices, offset, true, device);
+            auto slice_weights = weights_twos.unsqueeze(0).expand({Q_input, slices});
+            BsiQueryBatchCudaData out;
+            out.rows = Q_input;
+            out.slices = slices;
+            out.words_per_slice = words_per_slice;
+            out.offset = offset;
+            out.words = words.contiguous();
+            if (chunk_scale) {
+                TORCH_CHECK(scale.defined() && scale.dim() == 2, "Expected [Q, chunks] chunk scales");
+                out.slice_weights = slice_weights.contiguous();
+                out.chunk_scales = scale.contiguous();
+            } else {
+                TORCH_CHECK(scale.defined() && scale.dim() == 1, "Expected [Q] row scales");
+                out.slice_weights = (slice_weights * scale.unsqueeze(1)).contiguous();
+            }
+
+            if (profile_cuda) {
+                g_last_query_build_quantize_ns = static_cast<uint64_t>(quantize_ms * 1.0e6);
+                g_last_query_build_pack_ns = static_cast<uint64_t>(pack_ms * 1.0e6);
+                g_last_query_build_total_ns = g_last_query_build_quantize_ns + g_last_query_build_pack_ns;
+            } else {
+                g_last_query_build_quantize_ns = 0;
+                g_last_query_build_pack_ns = 0;
+                g_last_query_build_total_ns = 0;
+            }
+
+            if (verbose || bsi_cuda_should_log()) {
+                std::cout << "[BSI_CUDA] build_bsi_queries_cuda_batch_data (fused): "
+                          << "Q=" << Q_input
+                          << " slices=" << slices
+                          << " words_per_slice=" << words_per_slice
+                          << std::endl;
+            }
+            return out;
+        }
+    }
+
     cudaEvent_t quantize_start_evt = nullptr;
     cudaEvent_t quantize_end_evt = nullptr;
     if (profile_cuda) {

--- a/bsi_ops/csrc/cuda/bsi_vector_cuda.h
+++ b/bsi_ops/csrc/cuda/bsi_vector_cuda.h
@@ -76,3 +76,8 @@ bsi_cuda_quantize_debug(const torch::Tensor& values,
 BsiVectorCudaData create_bsi_vector_cuda_from_cpu(const BsiVector<uint64_t>& src,
                                                   const torch::Device& device,
                                                   bool verbose = false);
+
+// Last-call query build profiling (set by build_bsi_queries_cuda_batch_data when BSI_PROFILE=1).
+// Returns (quantize_ns, pack_ns, total_ns). Values are 0 when profiling is disabled.
+std::tuple<uint64_t, uint64_t, uint64_t> bsi_cuda_get_last_query_build_profile();
+void bsi_cuda_reset_last_query_build_profile();

--- a/bsi_ops/scripts/_common.sh
+++ b/bsi_ops/scripts/_common.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Shared defaults for bsi_ops scripts. Callers can override by exporting vars.
 : "${BSI_TC_DOT:=0}"
+: "${BSI_TC_TM:=0}"
 : "${BSI_WARP_OUT:=1}"
 : "${BSI_CK_BLOCK:=128}"
 : "${BSI_Q_TILE:=8}"
@@ -10,6 +11,7 @@ set -euo pipefail
 
 bsi_run() {
   BSI_TC_DOT="${BSI_TC_DOT}" \
+  BSI_TC_TM="${BSI_TC_TM}" \
   BSI_WARP_OUT="${BSI_WARP_OUT}" \
   BSI_CK_BLOCK="${BSI_CK_BLOCK}" \
   BSI_Q_TILE="${BSI_Q_TILE}" \

--- a/bsi_ops/scripts/_common.sh
+++ b/bsi_ops/scripts/_common.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # Shared defaults for bsi_ops scripts. Callers can override by exporting vars.
 : "${BSI_TC_DOT:=0}"
 : "${BSI_TC_TM:=0}"
-: "${BSI_TC_QS_SHARED:=1}"
 : "${BSI_WARP_OUT:=1}"
 : "${BSI_CK_BLOCK:=128}"
 : "${BSI_Q_TILE:=8}"
@@ -13,7 +12,6 @@ set -euo pipefail
 bsi_run() {
   BSI_TC_DOT="${BSI_TC_DOT}" \
   BSI_TC_TM="${BSI_TC_TM}" \
-  BSI_TC_QS_SHARED="${BSI_TC_QS_SHARED}" \
   BSI_WARP_OUT="${BSI_WARP_OUT}" \
   BSI_CK_BLOCK="${BSI_CK_BLOCK}" \
   BSI_Q_TILE="${BSI_Q_TILE}" \

--- a/bsi_ops/scripts/_common.sh
+++ b/bsi_ops/scripts/_common.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Shared defaults for bsi_ops scripts. Callers can override by exporting vars.
 : "${BSI_TC_DOT:=0}"
 : "${BSI_TC_TM:=0}"
+: "${BSI_TC_QS_SHARED:=1}"
 : "${BSI_WARP_OUT:=1}"
 : "${BSI_CK_BLOCK:=128}"
 : "${BSI_Q_TILE:=8}"
@@ -12,6 +13,7 @@ set -euo pipefail
 bsi_run() {
   BSI_TC_DOT="${BSI_TC_DOT}" \
   BSI_TC_TM="${BSI_TC_TM}" \
+  BSI_TC_QS_SHARED="${BSI_TC_QS_SHARED}" \
   BSI_WARP_OUT="${BSI_WARP_OUT}" \
   BSI_CK_BLOCK="${BSI_CK_BLOCK}" \
   BSI_Q_TILE="${BSI_Q_TILE}" \


### PR DESCRIPTION
Added default TM32 BMMA hot-path specialization for Sa=7,Sb=7 and Sa=7,Sb=6 in bsi_cuda_kernels_dot.cuh.
Specialization uses compile-time Sa/Sb in a dedicated helper (bsi_bmma_tm32_accum_sa7_sb_hot<6|7>), and is selected automatically in the kernel.
Factored chunk-scale multiply out of the inner i loop for these hot paths:
- accumulate per-row chunk contribution first
- apply qscale once per row per chunk
Left all other paths as-is fallback (no behavior change outside hot configs).

This also includes optimizations for forward_pass and build.